### PR TITLE
[Design] 사진 업로드, 탐정 선택 모달 뷰 컴포넌트 UI 구현

### DIFF
--- a/SherlDog/PictureUploadRequestView.swift
+++ b/SherlDog/PictureUploadRequestView.swift
@@ -1,0 +1,161 @@
+//
+//  PictureUploadRequestView.swift
+//  SherlDog
+//
+//  Created by 최규현 on 6/10/25.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+import SnapKit
+import RxDataSources
+import Differentiator
+
+// MARK: - PictureUploadView
+class PictureUploadRequestView: UIViewController {
+
+    private let viewModel: PictureUploadRequestViewModel?
+    private let disposeBag = DisposeBag()
+    private let dataSource = RxCollectionViewSectionedReloadDataSource<PictureUploadRequestViewModel.RequestSection>(
+        configureCell: { dataSource, collectionView, indexPath, section in
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PictureUploadRequestViewCell.identifier, for: indexPath) as? PictureUploadRequestViewCell else { return UICollectionViewCell() }
+            cell.settingCell(text: section.title, imageName: section.image)
+
+            return cell
+        }, configureSupplementaryView: { dataSource, collectionView, title, indexPath in
+            guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader,
+                                                                               withReuseIdentifier: PictureUploadRequestViewHeader.identifier,
+                                                                               for: indexPath) as? PictureUploadRequestViewHeader else { return UICollectionReusableView() }
+            let title = dataSource.sectionModels[indexPath.section].model
+            header.setTitle(title: title)
+
+            return header
+        }
+    )
+
+    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewCompositionalLayout())
+    private let setButton = UIButton()
+
+    init(viewModel: PictureUploadRequestViewModel?) {
+        self.viewModel = viewModel
+        self.viewModel?.input.accept(.sender(.pictureRequest)) // test
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Lifecycle
+extension PictureUploadRequestView {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupUI()
+        configureUI()
+        bind()
+    }
+
+}
+
+// MARK: - Method
+extension PictureUploadRequestView {
+
+    private func bind() {
+        self.viewModel?.output.cellData
+            .bind(to: self.collectionView.rx.items(dataSource: dataSource))
+            .disposed(by: disposeBag)
+        
+        self.viewModel?.output.buttonName
+            .subscribe(onNext: { [weak self] name in
+                guard let self else { return }
+                
+                self.setButton.setTitle(name, for: .normal)
+            })
+            .disposed(by: disposeBag)
+        
+        self.collectionView.rx.itemSelected
+            .subscribe(onNext: { [weak self] indexPath in
+                guard let self, let sender = self.viewModel?.output.sender.value else { return }
+                
+                switch sender {
+                case .pictureRequest, .pictureRequestWithIcon:
+                    
+                    self.collectionView.visibleCells.enumerated().forEach { index, item in
+                        if index == indexPath.row {
+                            item.isSelected.toggle()
+                        } else {
+                            item.isSelected = false
+                        }
+                    }
+                    
+                case .sherlDogRequest:
+                    self.collectionView.visibleCells[indexPath.row].isSelected.toggle()
+                    
+                case .sherlDogResult: return    // .sherlDogResult is read only
+                }
+                
+            })
+            .disposed(by: disposeBag)
+        
+        self.setButton.rx.tap
+            .subscribe { [weak self] _ in
+                guard let self else { return }
+                
+                var selectedIndex: [Int] = []
+                
+                self.collectionView.visibleCells.enumerated().forEach { index, item in
+                    if item.isSelected {
+                        selectedIndex.append(index)
+                    }
+                }
+                
+                self.viewModel?.input.accept(.setButtonTapped(selectedIndex))
+            }
+            .disposed(by: disposeBag)
+    }
+
+    private func setupUI() {
+        view.backgroundColor = .white
+        view.addSubview(collectionView)
+        view.addSubview(setButton)
+
+        collectionView.register(PictureUploadRequestViewCell.self,
+                                forCellWithReuseIdentifier: PictureUploadRequestViewCell.identifier)
+        collectionView.register(PictureUploadRequestViewHeader.self,
+                                forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+                                withReuseIdentifier: PictureUploadRequestViewHeader.identifier)
+    }
+
+    private func configureUI() {
+        collectionView.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(20)
+        }
+    }
+
+    private func collectionViewCompositionalLayout() -> UICollectionViewCompositionalLayout {
+        let item = NSCollectionLayoutItem(layoutSize: .init(widthDimension: .fractionalWidth(1),
+                                                            heightDimension: .absolute(70)))
+
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: .init(widthDimension: .fractionalWidth(1),
+                                                                       heightDimension: .fractionalHeight(1/5)),
+                                                     subitems: [item])
+
+        group.interItemSpacing = .fixed(12)
+
+        let section = NSCollectionLayoutSection(group: group)
+
+        let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: .init(widthDimension: .fractionalWidth(1),
+                                                                                   heightDimension: .estimated(60)),
+                                                                 elementKind: UICollectionView.elementKindSectionHeader,
+                                                                 alignment: .top)
+        section.boundarySupplementaryItems = [header]
+
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+}
+

--- a/SherlDog/PictureUploadRequestView.swift
+++ b/SherlDog/PictureUploadRequestView.swift
@@ -99,24 +99,41 @@ extension PictureUploadRequestView {
                 case .sherlDogResult: return    // .sherlDogResult is read only
                 }
                 
+                self.fetchButtonEnable()
             })
             .disposed(by: disposeBag)
         
         self.setButton.rx.tap
             .subscribe { [weak self] _ in
                 guard let self else { return }
+                // 함께 수사한 탐정 모달이면 창 닫고 끝냄
+                guard self.viewModel?.output.sender.value != .sherlDogResult else {
+                    self.dismiss(animated: true)
+                    return
+                }
                 
                 var selectedIndex: [Int] = []
                 
-                self.collectionView.visibleCells.enumerated().forEach { index, item in
-                    if item.isSelected {
-                        selectedIndex.append(index)
-                    }
+                collectionView.indexPathsForSelectedItems?.forEach {
+                    selectedIndex.append($0.row)
                 }
                 
                 self.viewModel?.input.accept(.setButtonTapped(selectedIndex))
             }
             .disposed(by: disposeBag)
+    }
+    
+    private func fetchButtonEnable() {
+        guard self.viewModel?.output.sender.value != .sherlDogResult else {
+            self.setButton.isEnabled = true
+            return
+        }
+        
+        if self.collectionView.indexPathsForSelectedItems == nil {
+            self.setButton.isEnabled = false
+        } else {
+            self.setButton.isEnabled = true
+        }
     }
 
     private func setupUI() {

--- a/SherlDog/PictureUploadRequestViewCell.swift
+++ b/SherlDog/PictureUploadRequestViewCell.swift
@@ -1,0 +1,61 @@
+//
+//  PictureUploadRequestViewCell.swift
+//  SherlDog
+//
+//  Created by 최규현 on 6/10/25.
+//
+
+import UIKit
+import SnapKit
+
+class PictureUploadRequestViewCell: UICollectionViewCell {
+
+    static let identifier: String = "PictureUploadRequestViewCell"
+
+    private let label = UILabel()
+    private let imageView = UIImageView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setupUI()
+        configureUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func settingCell(text: String, imageName: String) {
+        self.label.text = text
+//        self.imageView.image = UIImage(named: imageName)
+        imageView.image = UIImage(systemName: "camera.metering.center.weighted.average")
+        imageView.tintColor = .textPrimary
+    }
+
+    private func setupUI() {
+        [label, imageView].forEach {
+            contentView.addSubview($0)
+        }
+
+        contentView.layer.cornerRadius = 12
+        contentView.layer.borderColor = UIColor.gray200.cgColor
+        contentView.layer.borderWidth = 1
+
+        label.font = .title2
+        label.textColor = .textPrimary
+    }
+
+    private func configureUI() {
+        imageView.snp.makeConstraints {
+            $0.width.height.equalTo(30)
+            $0.leading.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+        }
+
+        label.snp.makeConstraints {
+            $0.leading.equalTo(imageView.snp.trailing).offset(16)
+            $0.centerY.equalToSuperview()
+        }
+    }
+}

--- a/SherlDog/PictureUploadRequestViewCell.swift
+++ b/SherlDog/PictureUploadRequestViewCell.swift
@@ -37,10 +37,22 @@ class PictureUploadRequestViewCell: UICollectionViewCell {
         [label, imageView].forEach {
             contentView.addSubview($0)
         }
+        
+        let cornerRadius: CGFloat = 12
+        
+        let selectedCell = UIView()
+        selectedCell.layer.cornerRadius = cornerRadius
+        selectedCell.backgroundColor = .gray100
+        
+        self.selectedBackgroundView = selectedCell
 
-        contentView.layer.cornerRadius = 12
+        contentView.layer.cornerRadius = cornerRadius
         contentView.layer.borderColor = UIColor.gray200.cgColor
         contentView.layer.borderWidth = 1
+        
+        if self.isSelected {
+            contentView.layer.borderColor = UIColor.textPrimary.cgColor
+        }
 
         label.font = .title2
         label.textColor = .textPrimary

--- a/SherlDog/PictureUploadRequestViewHeader.swift
+++ b/SherlDog/PictureUploadRequestViewHeader.swift
@@ -1,0 +1,45 @@
+//
+//  PictureUploadRequestViewHeader.swift
+//  SherlDog
+//
+//  Created by 최규현 on 6/10/25.
+//
+
+import UIKit
+import SnapKit
+
+class PictureUploadRequestViewHeader: UICollectionReusableView {
+
+    static let identifier: String = "PictureUploadRequestViewHeader"
+
+    private let titleLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setupUI()
+        configureUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setTitle(title: String) {
+        self.titleLabel.text = title
+    }
+
+    private func setupUI() {
+        self.addSubview(titleLabel)
+
+        titleLabel.font = .title1
+        titleLabel.textColor = .textPrimary
+    }
+
+    private func configureUI() {
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+        }
+    }
+}

--- a/SherlDog/PictureUploadRequestViewModel.swift
+++ b/SherlDog/PictureUploadRequestViewModel.swift
@@ -1,0 +1,133 @@
+//
+//  PictureUploadRequestViewModel.swift
+//  SherlDog
+//
+//  Created by 최규현 on 6/10/25.
+//
+
+import RxSwift
+import RxRelay
+import RxDataSources
+import Differentiator
+
+class PictureUploadRequestViewModel {
+    
+    enum RequestSender {
+        case pictureRequest
+        case pictureRequestWithIcon
+        case sherlDogRequest
+        case sherlDogResult
+    }
+    
+    struct CellList {
+        let title: String
+        let image: String
+    }
+    
+    enum Input {
+        case sender(RequestSender)
+        case setButtonTapped([Int])
+    }
+    
+    struct Output {
+        let sender = BehaviorRelay<RequestSender?>(value: nil)
+        let buttonName = BehaviorRelay<String>(value: "")
+        let cellData = BehaviorRelay(value: [RequestSection]())
+    }
+    
+    typealias RequestSection = SectionModel<String, CellList>
+    
+    private let disposeBag = DisposeBag()
+    
+    let input = PublishRelay<Input>()
+    let output = Output()
+    
+    init() {
+        self.transform()
+    }
+    
+    private func transform() {
+        self.input
+            .bind(onNext: { [weak self] input in
+                guard let self else { return }
+                
+                switch input {
+                    
+                case .sender(let sender):
+                    
+                    switch sender {
+                    case .pictureRequest:
+                        self.output.sender.accept(.pictureRequest)
+                        self.output.buttonName.accept("선택 완료")
+                        self.output.cellData.accept([
+                            RequestSection(model: "수사일지 사진 업로드",
+                                           items: [
+                                            CellList(title: "사진 찍기", image: "imageName"),
+                                            CellList(title: "사진 보관함", image: "imageName")
+                                           ])
+                        ])
+                    case .pictureRequestWithIcon:
+                        self.output.sender.accept(.pictureRequestWithIcon)
+                        self.output.buttonName.accept("선택 완료")
+                        self.output.cellData.accept([
+                            RequestSection(model: "프로필 사진 설정",
+                                           items: [
+                                            CellList(title: "기본 아바타 설정", image: "imageName"),
+                                            CellList(title: "사진 찍기", image: "imageName"),
+                                            CellList(title: "사진 보관함", image: "imageName"),
+                                           ])
+                        ])
+                    case .sherlDogRequest:
+                        self.output.sender.accept(.sherlDogRequest)
+                        self.output.buttonName.accept("선택 완료")
+                        self.output.cellData.accept([
+                            RequestSection(model: "어떤 탐정님과 수사를 하실 건가요?",
+                                           items: self.fetchSherlDogList())
+                        ])
+                    case .sherlDogResult:
+                        self.output.sender.accept(.sherlDogResult)
+                        self.output.buttonName.accept("닫기")
+                        self.output.cellData.accept([
+                            RequestSection(model: "오늘 수사에 함께한 탐정들",
+                                           items: self.fetchSherlDogList())
+                        ])
+                    }
+                    
+                case .setButtonTapped(let index):
+                    guard let sender = self.output.sender.value else { return }
+                    
+                    switch sender {
+                    case .pictureRequest:
+                        switch index.first {
+                        case 0: print("선택한 버튼: 사진 찍기")
+                        case 1: print("선택한 버튼: 사진 보관함")
+                        default: return
+                        }
+                        
+                    case .pictureRequestWithIcon:
+                        switch index.first {
+                        case 0: print("선택한 버튼: 기본 이미지 설정")
+                        case 1: print("선택한 버튼: 사진 찍기")
+                        case 2: print("선택한 버튼: 사진 보관함")
+                        default: return
+                        }
+                        
+                    case .sherlDogRequest:  // 산책갈 강아지 선택
+                        print("선택한 강아지: \(index)")
+                        
+                    case .sherlDogResult: return    // .sherlDogResult is read only
+                    }
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func fetchSherlDogList() -> [CellList] {
+        return [
+            CellList(title: "멍탐정 1", image: "imageName"),
+            CellList(title: "멍탐정 2", image: "imageName"),
+            CellList(title: "멍탐정 3", image: "imageName"),
+        ]
+    }
+    
+}

--- a/SherlDog/PictureUploadRequestViewModel.swift
+++ b/SherlDog/PictureUploadRequestViewModel.swift
@@ -112,8 +112,8 @@ class PictureUploadRequestViewModel {
                         default: return
                         }
                         
-                    case .sherlDogRequest:  // 산책갈 강아지 선택
-                        print("선택한 강아지: \(index)")
+                    case .sherlDogRequest:  // 수사할 탐정 선택
+                        print("함께 수사할 탐정: \(index)")
                         
                     case .sherlDogResult: return    // .sherlDogResult is read only
                     }


### PR DESCRIPTION
close #23 

## *⛳️ Work Description*

- 사진 업로드, 탐정 선택 요청 시 출력되는 모달 뷰 UI구현했습니다.
- 와이어 프레임 상 4개의 뷰에서 요청 가능할 것으로 판단해 4가지 분기처리 진행했습니다.
- 뷰에서 호출할 경우 PictureUploadRequestViewModel() 인스턴스 생성 후
  인스턴스.input.accept(.sender(해당하는 뷰)) 입력하시고 해당 뷰에 사용한 인스턴스 주입해서 호출하시면 됩니다.

## *📸 Screenshot*

| before | After | 
| -- | -- |
|  | <img src="https://github.com/user-attachments/assets/19717d24-821e-4f97-895a-f3735d38ed79"  width="300"/> |


## *📢 To Reviewers*

- 시뮬레이터 영상 녹화를 위해 기존 ViewController()에 테스트용 코드 추가해 기록 후 삭제했습니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
