### PR TITLE
[Refactor] 카메라 뷰 연결 방식 변경

### DIFF
--- a/SherlDog/Reusable/Camera/CameraViewController.swift
+++ b/SherlDog/Reusable/Camera/CameraViewController.swift
@@ -14,10 +14,10 @@ import AVFoundation
 // MARK: - CameraViewController
 class CameraViewController: UIViewController {
     
-    private let viewModel = CameraViewModel()
+    private let viewModel: CameraViewModel
     private let disposeBag = DisposeBag()
     
-    private var viewControllerForPicture: UIViewController
+    private var viewControllerForPicture: UIViewController?
     
     private let captureSession = AVCaptureSession()
     private let captureDevice = AVCaptureDevice.default(for: .video)
@@ -29,18 +29,8 @@ class CameraViewController: UIViewController {
     private let shutterButton = UIButton()
     
     // MARK: - Initialize
-    init(to destination: CameraDestination) {
-        switch destination {
-            
-        case .clueLeave:
-            self.viewControllerForPicture = UINavigationController(rootViewController: ClueInputViewController(viewModel: viewModel))
-        case .petProfile:
-            self.viewControllerForPicture = UINavigationController(rootViewController: PetProfileViewController()) // todo: 뷰모델 주입
-        case .assistantProfile:
-            self.viewControllerForPicture = UINavigationController(rootViewController: CreateAssistantProfileViewController()) // todo: 뷰모델 주입
-        case .communityShare:
-            self.viewControllerForPicture = UINavigationController(rootViewController: CreateLogViewController(viewModel: viewModel))
-        }
+    init(viewModel: CameraViewModel) {
+        self.viewModel = viewModel
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -48,7 +38,6 @@ class CameraViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
 }
 
 // MARK: - Lifecycle
@@ -110,6 +99,22 @@ extension CameraViewController {
     }
     
     private func bind() {
+        self.viewModel.output.sender
+            .subscribe(onNext: { [weak self] sender in
+                guard let self else { return }
+                
+                switch sender {
+                case .clueLeave:
+                    self.viewControllerForPicture = UINavigationController(rootViewController: ClueInputViewController(viewModel: viewModel))
+                    
+                case .communityShare:
+                    self.viewControllerForPicture = UINavigationController(rootViewController: CreateLogViewController(viewModel: viewModel))
+                    
+                case .profile: return
+                }
+            })
+            .disposed(by: disposeBag)
+        
         self.viewModel.output.getCapture
             .subscribe { [weak self] _ in
                 guard let self else { return }
@@ -196,20 +201,26 @@ extension CameraViewController {
 extension CameraViewController: AVCapturePhotoCaptureDelegate {
     func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: (any Error)?) {
         guard let imageData = photo.fileDataRepresentation(),
-        let image = UIImage(data: imageData) else { return }
+              let image = UIImage(data: imageData) else { return }
         
         self.viewModel.input.accept(.captureImage(image))
         
         DispatchQueue.global().async {
             self.captureSession.stopRunning()
         }
+        guard let viewControllerForPicture else { return }
         
-        DispatchQueue.main.async {
-            self.present(self.viewControllerForPicture, animated: true)
+        switch self.viewModel.output.sender.value {
+        case .profile:
+            DispatchQueue.main.async {
+                self.presentingViewController?.presentingViewController?.dismiss(animated: true)
+            }
+            
+        case .clueLeave, .communityShare:
+            DispatchQueue.main.async {
+                self.present(viewControllerForPicture, animated: true)
+            }
+            
         }
     }
-}
-
-enum CameraDestination {
-    case clueLeave, petProfile, assistantProfile, communityShare
 }

--- a/SherlDog/Reusable/Camera/CameraViewModel.swift
+++ b/SherlDog/Reusable/Camera/CameraViewModel.swift
@@ -11,7 +11,12 @@ import UIKit
 
 class CameraViewModel {
     
+    enum CameraDestination {
+        case profile, clueLeave, communityShare
+    }
+    
     enum Input {
+        case sender(CameraDestination)
         case shutterButtonTap
         case captureImage(UIImage)
         case pinchGestureBegan(CGFloat)
@@ -20,6 +25,7 @@ class CameraViewModel {
     }
     
     struct Output {
+        let sender = BehaviorRelay<CameraDestination>(value: .profile)
         let getCapture = PublishRelay<Void>()
         let capturedImage = BehaviorRelay<UIImage?>(value: nil)
         let pinchUpdate = PublishRelay<CGFloat>()
@@ -42,6 +48,9 @@ class CameraViewModel {
         
         input.bind { input in
             switch input {
+            case .sender(let sender):
+                self.output.sender.accept(sender)
+                
             case .shutterButtonTap:
                 self.output.getCapture.accept(())
                 

--- a/SherlDog/Reusable/Component/PictureUploadRequestView.swift
+++ b/SherlDog/Reusable/Component/PictureUploadRequestView.swift
@@ -15,7 +15,8 @@ import Differentiator
 // MARK: - PictureUploadView
 class PictureUploadRequestView: UIViewController {
 
-    private let viewModel: PictureUploadRequestViewModel?
+    private let viewModel: PictureUploadRequestViewModel
+    private let cameraViewModel: CameraViewModel?
     private let disposeBag = DisposeBag()
     private let dataSource = RxCollectionViewSectionedReloadDataSource<PictureUploadRequestViewModel.RequestDataSource>(
         configureCell: { dataSource, collectionView, indexPath, section in
@@ -37,9 +38,11 @@ class PictureUploadRequestView: UIViewController {
 
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewCompositionalLayout())
     private let setButton = UIButton()
-
-    init(viewModel: PictureUploadRequestViewModel?) {
+    
+    // MARK: - Lifecycle
+    init(viewModel: PictureUploadRequestViewModel, cameraViewModel: CameraViewModel? = nil) {
         self.viewModel = viewModel
+        self.cameraViewModel = cameraViewModel
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -47,11 +50,7 @@ class PictureUploadRequestView: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-}
-
-// MARK: - Lifecycle
-extension PictureUploadRequestView {
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -65,18 +64,17 @@ extension PictureUploadRequestView {
         super.viewWillAppear(animated)
         self.navigationController?.navigationBar.isHidden = true
     }
-
 }
 
 // MARK: - Method
 extension PictureUploadRequestView {
 
     private func outputBind() {
-        self.viewModel?.output.cellData
+        self.viewModel.output.cellData
             .bind(to: self.collectionView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
         
-        self.viewModel?.output.sender
+        self.viewModel.output.sender
             .subscribe(onNext: { sender in
                 guard let sender else { return }
                 switch sender {
@@ -96,7 +94,7 @@ extension PictureUploadRequestView {
             })
             .disposed(by: disposeBag)
         
-        self.viewModel?.output.buttonName
+        self.viewModel.output.buttonName
             .subscribe(onNext: { [weak self] name in
                 guard let self else { return }
                 
@@ -105,19 +103,33 @@ extension PictureUploadRequestView {
             })
             .disposed(by: disposeBag)
         
-        self.viewModel?.output.moveToView
+        self.viewModel.output.moveToView
             .subscribe(onNext: { [weak self] list in
+                guard let self,
+                      let cameraViewModel,
+                      let sender = self.viewModel.output.sender.value else { return }
+                
+                switch sender {
+                case .pictureRequest:
+                    cameraViewModel.input.accept(.sender(.communityShare))
+                    
+                case .pictureRequestWithIcon:
+                    cameraViewModel.input.accept(.sender(.profile))
+                    
+                case .sherlDogRequest, .sherlDogResult: break
+                }
+                
                 switch list {
                 case .camera:
-                    let cameraView = UINavigationController(rootViewController: CameraViewController(to: .communityShare))
+                    let cameraView = UINavigationController(rootViewController: CameraViewController(viewModel: cameraViewModel))
                     cameraView.modalPresentationStyle = .fullScreen
-                    self?.present(cameraView, animated: true)
+                    self.present(cameraView, animated: true)
                     
                 case .album:
                     print("album")
                     
                 case .avatar:
-                    self?.navigationController?.pushViewController(SelectAvatarViewController(), animated: true)
+                    self.navigationController?.pushViewController(SelectAvatarViewController(), animated: true)
                 }
             })
             .disposed(by: disposeBag)
@@ -142,7 +154,7 @@ extension PictureUploadRequestView {
             .subscribe { [weak self] _ in
                 guard let self else { return }
                 // 함께 수사한 탐정 모달이면 창 닫고 끝냄
-                guard self.viewModel?.output.sender.value != .sherlDogResult else {
+                guard self.viewModel.output.sender.value != .sherlDogResult else {
                     self.dismiss(animated: true)
                     return
                 }
@@ -153,13 +165,13 @@ extension PictureUploadRequestView {
                     selectedIndex.append($0.row)
                 }
                 
-                self.viewModel?.input.accept(.setButtonTapped(selectedIndex))
+                self.viewModel.input.accept(.setButtonTapped(selectedIndex))
             }
             .disposed(by: disposeBag)
     }
     
     private func fetchButtonEnable() {
-        guard self.viewModel?.output.sender.value != .sherlDogResult else {
+        guard self.viewModel.output.sender.value != .sherlDogResult else {
             self.setButton.isEnabled = true
             return
         }

--- a/SherlDog/Scene/HomeTap/Main/MainViewController.swift
+++ b/SherlDog/Scene/HomeTap/Main/MainViewController.swift
@@ -58,7 +58,10 @@ class MainViewController: UIViewController {
     private func inputBind() {
         self.clueButton.rx.tap
             .subscribe(onNext: { [weak self] _ in
-                let cameraView = UINavigationController(rootViewController: CameraViewController(to: .clueLeave))
+                let cameraViewModel = CameraViewModel()
+                cameraViewModel.input.accept(.sender(.clueLeave))
+                
+                let cameraView = UINavigationController(rootViewController: CameraViewController(viewModel: cameraViewModel))
                 cameraView.modalPresentationStyle = .fullScreen
                 self?.present(cameraView, animated: true)
             })

--- a/SherlDog/Scene/User/HumanProfile/CreateAssistantProfileViewController.swift
+++ b/SherlDog/Scene/User/HumanProfile/CreateAssistantProfileViewController.swift
@@ -13,6 +13,7 @@ import SnapKit
 // MARK: - AssistantProfileViewController
 class CreateAssistantProfileViewController: UIViewController {
     
+    private let cameraViewModel = CameraViewModel()
     private let disposeBag = DisposeBag()
     
     private let navigationBackButton = UIButton()
@@ -43,6 +44,13 @@ class CreateAssistantProfileViewController: UIViewController {
 extension CreateAssistantProfileViewController {
     
     private func bind() {
+        self.cameraViewModel.output.capturedImage
+            .subscribe(onNext: { [weak self] image in
+                guard let self, let image else { return }
+                self.profileImageView.image = image
+            })
+            .disposed(by: disposeBag)
+        
         self.nicknameTextField.rx.text
             .subscribe(onNext: { [weak self] _ in
                 guard let self,
@@ -83,7 +91,8 @@ extension CreateAssistantProfileViewController {
                 guard let self else { return }
                 let pictureViewModel = PictureUploadRequestViewModel()
                 pictureViewModel.input.accept(.sender(.pictureRequestWithIcon))
-                let requestView = UINavigationController(rootViewController: PictureUploadRequestView(viewModel: pictureViewModel))
+                
+                let requestView = UINavigationController(rootViewController: PictureUploadRequestView(viewModel: pictureViewModel, cameraViewModel: cameraViewModel))
                 requestView.modalPresentationStyle = .pageSheet
                 
                 if let sheet = requestView.sheetPresentationController {
@@ -92,6 +101,7 @@ extension CreateAssistantProfileViewController {
                     sheet.prefersGrabberVisible = true
                     sheet.preferredCornerRadius = 32
                 }
+                
                 self.present(requestView, animated: true)
             })
             .disposed(by: disposeBag)
@@ -134,7 +144,8 @@ extension CreateAssistantProfileViewController {
         self.navigationItem.titleView = navigationTitleLabel
         
         profileImageView.image = UIImage(systemName: "person.crop.circle.fill")
-        profileImageView.contentMode = .scaleAspectFit
+        profileImageView.contentMode = .scaleAspectFill
+        profileImageView.clipsToBounds = true
         profileImageView.tintColor = .gray300
         
         profileCameraButtonImageView.image = UIImage(systemName: "camera.circle.fill")
@@ -181,23 +192,25 @@ extension CreateAssistantProfileViewController {
     }
     
     private func configureUI() {
-        let profileButtonLeadingInset: CGFloat = 117.5
+        let profileButtonSize: CGFloat = 140
+        let profileImageInset: CGFloat = 8
+        let profileCameraButtonSize: CGFloat = 44
+        
+        profileImageView.layer.cornerRadius = (profileButtonSize - profileImageInset) / 2
         
         profileimageSetbutton.snp.makeConstraints {
+            $0.height.width.equalTo(profileButtonSize)
             $0.top.equalTo(view.safeAreaLayoutGuide).inset(16)
-            $0.leading.trailing.equalToSuperview().inset(profileButtonLeadingInset)
-            // 다른 기기 대응을 위해 계산한 값입니다.
-            $0.height.equalTo(UIScreen.main.bounds.width - (profileButtonLeadingInset * 2))
+            $0.centerX.equalToSuperview()
         }
         
         profileImageView.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
-            $0.trailing.bottom.equalToSuperview().inset(8)
+            $0.trailing.bottom.equalToSuperview().inset(profileImageInset)
         }
         
         profileCameraButtonImageView.snp.makeConstraints {
-            // 다른 기기 대응을 위해 mulptipliedBy로 크기 잡았습니다. 와이어프레임에서 계산해봤을 때 3.1818... 나오길래 3.18로 잘랐습니다.
-            $0.height.width.equalTo(profileimageSetbutton.snp.height).multipliedBy(1.0 / 3.18)
+            $0.height.width.equalTo(profileCameraButtonSize)
             $0.trailing.bottom.equalToSuperview().inset(4)
         }
         

--- a/SherlDog/Scene/User/PetProfile/RegistrationViewController.swift
+++ b/SherlDog/Scene/User/PetProfile/RegistrationViewController.swift
@@ -12,6 +12,7 @@ import RxCocoa
 
 class RegistrationViewController: UIViewController {
     
+    private let cameraViewModel = CameraViewModel()
     let disposeBag = DisposeBag()
     
     let registrationLabel = UILabel()
@@ -63,12 +64,20 @@ class RegistrationViewController: UIViewController {
     
     func bind() {
         
+        cameraViewModel.output.capturedImage
+            .subscribe(onNext: { [weak self] image in
+                guard let self, let image else { return }
+                // todo: 사진 삽입
+                self.registImage.setImage(image, for: .normal) // test
+            })
+            .disposed(by: disposeBag)
+        
         self.registImage.rx.tap
             .subscribe(onNext: { [weak self] _ in
                 guard let self else { return }
                 let pictureViewModel = PictureUploadRequestViewModel()
                 pictureViewModel.input.accept(.sender(.pictureRequestWithIcon))
-                let requestView = UINavigationController(rootViewController: PictureUploadRequestView(viewModel: pictureViewModel))
+                let requestView = UINavigationController(rootViewController: PictureUploadRequestView(viewModel: pictureViewModel, cameraViewModel: cameraViewModel))
                 requestView.modalPresentationStyle = .pageSheet
                 
                 if let sheet = requestView.sheetPresentationController {


### PR DESCRIPTION
close #70 

## *⛳️ Work Description*

- 기존: 카메라 뷰가 사진을 전송할 때 전송할 뷰에 의존성을 주입하는 방식
- 변경 후: 사진을 전송받을 뷰가 카메라 뷰모델을 가지고 있고 카메라를 호출할 때 의존성 주입을 하는 방법
- 카메라를 거쳐야 생성되는 뷰는 기존 방식 그대로 사용했습니다.

## *📸 Screenshot*

외관 상 변경된 부분이 없어서 스크린 샷이 없습니다.

## *📢 To Reviewers*

- 펫 프로필 만드는 뷰에서 이미지를 담을 뷰를 생성해야 할 듯 합니다.
- 일단 사진을 제대로 불러오는지 확인하기 위해 프로필 버튼에 setImage를 임시로 넣어뒀습니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
