### PR TITLE
[Feat] 카메라, 앨범 권한 요청하는 로직 추가

### DIFF
--- a/SherlDog/Reusable/Camera/PermissionManager.swift
+++ b/SherlDog/Reusable/Camera/PermissionManager.swift
@@ -1,0 +1,47 @@
+//
+//  PermissionManager.swift
+//  SherlDog
+//
+//  Created by 최규현 on 6/17/25.
+//
+
+import PhotosUI
+
+class PermissionManager {
+    
+    static func requestPermission(type: PermissionType, completion: @escaping (Bool) -> ()) {
+        switch type {
+        case .camera:
+            self.requestCameraPermission(completion: completion)
+        case .album:
+            self.requestAlbumPermission(completion: completion)
+        }
+    }
+    
+    private static func requestAlbumPermission(completion: @escaping (Bool) -> ()) {
+        PHPhotoLibrary.requestAuthorization(for: .readWrite) { status in
+            DispatchQueue.main.async {
+                switch status {
+                case .authorized, .limited:
+                    completion(true)
+                case .notDetermined, .denied, .restricted:
+                    completion(false)
+                @unknown default:
+                    completion(false)
+                }
+            }
+        }
+    }
+    
+    private static func requestCameraPermission(completion: @escaping (Bool) -> ()) {
+        AVCaptureDevice.requestAccess(for: .video) { request in
+            DispatchQueue.main.async {
+                completion(request)
+            }
+        }
+    }
+}
+
+enum PermissionType {
+    case camera, album
+}

--- a/SherlDog/Reusable/Component/PictureUploadRequestView.swift
+++ b/SherlDog/Reusable/Component/PictureUploadRequestView.swift
@@ -120,13 +120,35 @@ extension PictureUploadRequestView {
                 
                 switch list {
                 case .camera:
-                    let cameraView = UINavigationController(rootViewController: CameraViewController(viewModel: cameraViewModel))
-                    cameraView.modalPresentationStyle = .fullScreen
-                    self.present(cameraView, animated: true)
+                    PermissionManager.requestPermission(type: .camera) { [weak self] isAllowed in
+                        guard let self else { return }
+                        switch isAllowed {
+                        case true:
+                            let cameraView = UINavigationController(rootViewController: CameraViewController(viewModel: self.cameraViewModel))
+                            cameraView.modalPresentationStyle = .fullScreen
+                            self.present(cameraView, animated: true)
+                            
+                        case false:
+                            let alert = AlertManager(message: "카메라 권한이 필요합니다.\n 설정에서 변경해주세요.", buttonTitles: ["확인"], buttonActions: [nil])
+                            
+                            self.present(alert, animated: true)
+                        }
+                    }
                     
                 case .album:
-                    let albumView = UINavigationController(rootViewController: AlbumViewController(viewModel: cameraViewModel))
-                    self.present(albumView, animated: true)
+                    PermissionManager.requestPermission(type: .album) { [weak self] isAllowed in
+                        guard let self else { return }
+                        switch isAllowed {
+                        case true:
+                            let albumView = UINavigationController(rootViewController: AlbumViewController(viewModel: cameraViewModel))
+                            self.present(albumView, animated: true)
+                            
+                        case false:
+                            let alert = AlertManager(message: "앨범 권한이 필요합니다.\n 설정에서 변경해주세요.", buttonTitles: ["확인"], buttonActions: [nil])
+                            
+                            self.present(alert, animated: true)
+                        }
+                    }
                     
                 case .avatar:
                     self.navigationController?.pushViewController(SelectAvatarViewController(), animated: true)


### PR DESCRIPTION
close #17 

## *⛳️ Work Description*

- 카메라, 앨범을 호출 시 권한이 없다면 실행되지 않도록 구현했습니다.

## *📸 Screenshot*

| before | After | 
| -- | -- |
|  | <img src="https://github.com/user-attachments/assets/bd83c382-e568-4193-8aad-60b9cd0f48a7"  width="300"/> |

## *📢 To Reviewers*

- 알럿 문구에 "카메라 or 앨범 권한이 필요합니다.\n 설정에서 변경해주세요." 라고 입력했는데
  알럿 매니저에는 줄 바꿈 기능이 구현이 안 돼있어서 나중에 문구변경 혹은 알럿매니저 수정이 필요할 듯 싶습니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
