### PR TITLE
[Feat] 카메라 뷰 누락된 UI 추가

### DIFF
--- a/SherlDog/Reusable/Camera/CameraViewController.swift
+++ b/SherlDog/Reusable/Camera/CameraViewController.swift
@@ -27,6 +27,8 @@ class CameraViewController: UIViewController {
     private let cameraView = UIView()
     private let pinchGesture = UIPinchGestureRecognizer()
     private let shutterButton = UIButton()
+    private let cancelButton = UIButton()
+    private let guideLabel = UILabel()
     
     // MARK: - Initialize
     init(viewModel: CameraViewModel) {
@@ -53,6 +55,12 @@ extension CameraViewController {
         inputBind()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.navigationController?.navigationBar.isHidden = true
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
@@ -64,6 +72,12 @@ extension CameraViewController {
 extension CameraViewController {
     
     private func inputBind() {
+        cancelButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                self?.dismiss(animated: true)
+            })
+            .disposed(by: disposeBag)
+        
         shutterButton.rx.tap
             .subscribe(onNext: { [weak self] _ in
                 self?.viewModel.input.accept(.shutterButtonTap)
@@ -88,6 +102,8 @@ extension CameraViewController {
     }
     
     private func bind() {
+        // todo: guideLabel text설정
+        
         self.viewModel.output.sender
             .subscribe(onNext: { [weak self] sender in
                 guard let self else { return }
@@ -95,6 +111,7 @@ extension CameraViewController {
                 switch sender {
                 case .clueLeave:
                     self.viewControllerForPicture = UINavigationController(rootViewController: ClueInputViewController(viewModel: viewModel))
+                    self.guideLabel.isHidden = false
                     
                 case .communityShare:
                     self.viewControllerForPicture = UINavigationController(rootViewController: CreateLogViewController(viewModel: viewModel))
@@ -154,13 +171,25 @@ extension CameraViewController {
     private func setupUI() {
         guard let previewLayer else { return }
         
-        [cameraView, shutterButton]
+        [cameraView, shutterButton, guideLabel, cancelButton]
             .forEach { view.addSubview($0) }
         
         cameraView.layer.insertSublayer(previewLayer, at: 0)
         cameraView.addGestureRecognizer(pinchGesture)
         
         previewLayer.videoGravity = .resizeAspectFill
+        
+        cancelButton.setImage(.modalExit.withRenderingMode(.alwaysTemplate), for: .normal)
+        cancelButton.imageView?.tintColor = .textInverse
+        
+        guideLabel.text = "(강쥐이름)과의 추억을 단서로 남겨보세요!"
+        guideLabel.textColor = .textInverse
+        guideLabel.font = .highlight5
+        guideLabel.backgroundColor = .gray600.withAlphaComponent(0.3)
+        guideLabel.textAlignment = .center
+        guideLabel.layer.cornerRadius = 6
+        guideLabel.clipsToBounds = true
+        guideLabel.isHidden = true
         
         shutterButton.setImage(UIImage(named: "cameraShutter"), for: .normal)
     }
@@ -174,6 +203,17 @@ extension CameraViewController {
             $0.width.height.equalTo(72)
             $0.centerX.equalToSuperview()
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(36)
+        }
+        
+        cancelButton.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.trailing.equalToSuperview().inset(18)
+        }
+        
+        guideLabel.snp.makeConstraints {
+            $0.top.equalTo(cancelButton.snp.bottom).offset(18)
+            $0.leading.trailing.equalToSuperview().inset(33.5)
+            $0.height.equalTo(56)
         }
     }
     


### PR DESCRIPTION
close #144 

## *⛳️ Work Description*

- 카메라 뷰의 누락된 UI추가했습니다.
  - 닫기 버튼
  - 가이드 라벨

## *📸 Screenshot*

| before | After | 
| -- | -- |
| <img src="https://github.com/user-attachments/assets/9d4df576-37ee-4c2c-bc7c-7b94c41e436a"  width="300"/> | <img src="https://github.com/user-attachments/assets/0ffb8788-7584-4f71-b884-4808445f8ba3"  width="300"/> |

## *📢 To Reviewers*

- 가이드 라벨의 백그라운드 컬러가 피그마 상 Hex코드로 표시되어 있길래
  비슷해보이는 gray600 컬러에 alpha값 0.3으로 지정했습니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
