### PR TITLE
[Fix] 경로 캡쳐 기능 수정

### DIFF
--- a/SherlDog/Scene/HomeTap/Main/MainViewController.swift
+++ b/SherlDog/Scene/HomeTap/Main/MainViewController.swift
@@ -110,6 +110,48 @@ class MainViewController: UIViewController {
     }
     
     private func bind() {
+        viewModel.fullSideOfCourse
+            .subscribe(onNext: { [weak self] fullSide in
+                guard let self else { return }
+                
+                // WalkendModalViewController의 imageView에 맞게 들어가도록 예측한 값.
+                /*
+                 top 25추정 + 박스사이즈(약 120추정) + 15 + 박스사이즈(약 150추정) + 60 + 라벨사이즈(약 24추정) + 75 = 469
+                 bottom 140 + 버튼사이즈(52) + 24추정(이미지뷰는 아래 버튼에 -12로 걸려있고, 아래 버튼은 이미지 뷰에 24로 걸려있음) = 216
+                 합 약 685
+                 paddingInsets의 top, bottom을 300씩 줘 여유공간 85, top, bottom 각각 42정도 확보
+                 leading, trailing도 비슷한 수준의 여유공간 50을 설정
+                 */
+                let paddingInset = UIEdgeInsets(top: 300, left: 50, bottom: 300, right: 50)
+                let cameraUpdate = NMFCameraUpdate(fit: fullSide, paddingInsets: paddingInset)
+                cameraUpdate.animation = .easeIn
+                self.mapView.moveCamera(cameraUpdate)
+                
+                // 설정된 animationDuration에 0.1초의 여유시간을 주고 그 이후에 코드가 실행되도록 설정
+                let duration = max(self.mapView.animationDuration, cameraUpdate.animationDuration) + 0.1
+                
+                DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+                    if let window = self.view.window {
+                        let renderer = UIGraphicsImageRenderer(bounds: window.bounds)
+                        let image = renderer.image { ctx in
+                            window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+                        }
+                        self.DataTrackingVM.capturedImage.accept(image)
+                    }
+                    
+                    let endVC = WalkEndModalViewController(viewModel: self.DataTrackingVM)
+                    let nav = UINavigationController(rootViewController: endVC)
+                    nav.modalPresentationStyle = .overFullScreen
+                    self.present(nav, animated: true)
+                    
+                    self.pathOverlays.forEach { $0.mapView = nil }
+                    self.pathOverlays.removeAll()
+                    self.setInvestigation(active: false)
+                    self.viewModel.coordinates.accept([])
+                }
+            })
+            .disposed(by: disposeBag)
+        
         viewModel.coordinates
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] (coords: [CLLocationCoordinate2D]) in
@@ -189,22 +231,6 @@ class MainViewController: UIViewController {
             .subscribe(onNext: { [weak self] _ in
                 self?.DataTrackingVM.stopTracking()
                 self?.viewModel.stopTracking.accept(())
-                if let window = self?.view.window {
-                    let renderer = UIGraphicsImageRenderer(bounds: window.bounds)
-                    let image = renderer.image { ctx in
-                        window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
-                    }
-                    self?.DataTrackingVM.capturedImage.accept(image)
-                }
-                
-                guard let viewModel = self?.DataTrackingVM else { return }
-                let endVC = WalkEndModalViewController(viewModel: viewModel)
-                let nav = UINavigationController(rootViewController: endVC)
-                nav.modalPresentationStyle = .overFullScreen
-                self?.present(nav, animated: true)
-                self?.pathOverlays.forEach { $0.mapView = nil }
-                self?.pathOverlays.removeAll()
-                self?.setInvestigation(active: false)
             })
             .disposed(by: disposeBag)
         

--- a/SherlDog/Scene/HomeTap/Main/MainViewModel.swift
+++ b/SherlDog/Scene/HomeTap/Main/MainViewModel.swift
@@ -9,11 +9,13 @@ import RxSwift
 import RxCocoa
 import CoreLocation
 import RxCoreLocation
+import NMapsMap
 
 final class MainViewModel {
     
     let startTracking = PublishRelay<Void>()
     let stopTracking = PublishRelay<Void>()
+    let fullSideOfCourse = PublishRelay<NMGLatLngBounds>()
     let isTracking = BehaviorRelay<Bool>(value: false)
 
     let coordinates = BehaviorRelay<[CLLocationCoordinate2D]>(value: [])
@@ -35,8 +37,9 @@ final class MainViewModel {
         
         stopTracking
             .subscribe(onNext: { [weak self] in
-                self?.isTracking.accept(false)
-                self?.coordinates.accept([])
+                guard let self else { return }
+                self.isTracking.accept(false)
+                self.fullSideOfCourse.accept(self.fetchFullSide())
             })
             .disposed(by: disposeBag)
     }
@@ -68,5 +71,15 @@ final class MainViewModel {
                 }
             })
             .disposed(by: disposeBag)
+    }
+    
+    private func fetchFullSide() -> NMGLatLngBounds {
+        var latLng = [NMGLatLng]()
+        
+        self.coordinates.value.forEach {
+            latLng.append(NMGLatLng(lat: $0.latitude, lng: $0.longitude))
+        }
+        
+        return NMGLatLngBounds(latLngs: latLng)
     }
 }


### PR DESCRIPTION
close #152 

## *⛳️ Work Description*

- 수사 종료하기 버튼을 누르면 그려진 경로가 모두 보이는 지점으로 이동 후 캡처 로직 실행
- 카메라를 먼저 이동시킨 뒤 이동에 걸리는 시간 + 0.1초 뒤 로직 실행됩니다.
- 카메라를 기울인 값은 카메라 이동 시 초기화되며 실행됩니다.

## *📸 Screenshot*

| before | After | 
| -- | -- |
|  | <img src="https://github.com/user-attachments/assets/4ce7048e-05b9-4f28-8bae-c5a8f6476afc"  width="300"/> |

## *📢 To Reviewers*

- 현재 캡처로직이 풀스크린을 캡처한 뒤 WalkEnd뷰의 이미지 뷰에 scaleAspectFill 형태로 채워지는 형태이기에
  카메라의 이동 위치를 이미지뷰에 적당한 사이즈로 들어갈 만큼의 위치를 계산해 넣었습니다.
- 메인 뷰에서 풀스크린 캡처 후 이미지를 잘라서 보내는 방법도 있긴 하지만
  결국에는 WalkEnd뷰의 imageView에 맞게 들어가야 하기 때문에 해당 방법으로 진행했습니다.
- 이후 FireBase에 업로드하는 로직은 WalkEnd뷰에서 이미지뷰를 캡처해서 실행해야 할 듯 합니다.
- MainViewModel에 fullSideOfCourse라는 이름의 PublishRelay< NMGLatLngBounds> 프로퍼티 생성했습니다.
- 메인 뷰의 endButton.rx.tap에서 실행하던 로직들의 위치를 fullSideOfCourse 구독 위치로 이동했습니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
