### PR TITLE
[Fix] 다크모드 대응되도록 수정(조수프로필 기본아바타 선택, 펫프로필 견종 선택 selected Cell)

### DIFF
--- a/SherlDog/Application/SceneDelegate.swift
+++ b/SherlDog/Application/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // 로그인 상태 확인 후 초기 화면 결정
        let initialViewController = determineInitialViewController()
         
-        window.rootViewController = UINavigationController(rootViewController: CreateAssistantProfileViewController())
+        window.rootViewController = initialViewController
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/SherlDog/Application/SceneDelegate.swift
+++ b/SherlDog/Application/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // 로그인 상태 확인 후 초기 화면 결정
        let initialViewController = determineInitialViewController()
         
-        window.rootViewController = initialViewController
+        window.rootViewController = UINavigationController(rootViewController: CreateAssistantProfileViewController())
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/SherlDog/Scene/User/HumanProfile/CreateAssistantProfileViewController.swift
+++ b/SherlDog/Scene/User/HumanProfile/CreateAssistantProfileViewController.swift
@@ -54,10 +54,9 @@ extension CreateAssistantProfileViewController {
             self.cameraViewModel.output.capturedImage,
             self.avatarViewModel.output.selectedAvatar,
             self.nicknameTextField.rx.text,
-            self.introduceTextView.rx.text,
-            self.viewModel.isLoading
+            self.introduceTextView.rx.text
         )
-        .subscribe(onNext: { [weak self] image, avatar, nickName, introduce, isLoading in
+        .subscribe(onNext: { [weak self] image, avatar, nickName, introduce in
             if image != nil || avatar != nil,
                nickName != "",
                introduce != "" {
@@ -70,11 +69,6 @@ extension CreateAssistantProfileViewController {
                 }
                 
             } else {
-                self?.nextButton.isEnabled = false
-            }
-            
-            // 로딩 중이라면 버튼 비활성
-            if isLoading {
                 self?.nextButton.isEnabled = false
             }
         })
@@ -193,7 +187,7 @@ extension CreateAssistantProfileViewController {
         // 로딩 상태 처리
         viewModel.isLoading
             .subscribe(onNext: { [weak self] isLoading in
-                // 로딩 중일 때 버튼이 비활성화되는 로직은 Observable.combineLatest 쪽에서 처리함
+                self?.nextButton.isEnabled = !isLoading
                 // 로딩 인디케이터가 있다면 여기서 처리
             })
             .disposed(by: disposeBag)

--- a/SherlDog/Scene/User/HumanProfile/CreateAssistantProfileViewController.swift
+++ b/SherlDog/Scene/User/HumanProfile/CreateAssistantProfileViewController.swift
@@ -50,6 +50,36 @@ class CreateAssistantProfileViewController: UIViewController {
 extension CreateAssistantProfileViewController {
     
     private func bind() {
+        Observable.combineLatest(
+            self.cameraViewModel.output.capturedImage,
+            self.avatarViewModel.output.selectedAvatar,
+            self.nicknameTextField.rx.text,
+            self.introduceTextView.rx.text,
+            self.viewModel.isLoading
+        )
+        .subscribe(onNext: { [weak self] image, avatar, nickName, introduce, isLoading in
+            if image != nil || avatar != nil,
+               nickName != "",
+               introduce != "" {
+                if let nickName, nickName.contains(" ") {
+                    self?.nextButton.isEnabled = false
+                    
+                } else {
+                    self?.nextButton.isEnabled = true
+                    
+                }
+                
+            } else {
+                self?.nextButton.isEnabled = false
+            }
+            
+            // 로딩 중이라면 버튼 비활성
+            if isLoading {
+                self?.nextButton.isEnabled = false
+            }
+        })
+        .disposed(by: disposeBag)
+        
         navigationBackButton.rx.tap
                 .subscribe(onNext: { [weak self] in
                     self?.navigationController?.popViewController(animated: true)
@@ -85,20 +115,13 @@ extension CreateAssistantProfileViewController {
                 
                 self.nickNameConstraintsLabel.text = "\(text.count) / 12자"
                 
-                if text.count > 0 {
-                    if text.contains(" ") {
-                        self.nickNameSeparatorAlert.isHidden = false
-                        self.nickNameSeparatorAlertImage.isHidden = false
-                        self.nextButton.isEnabled = false
-                        
-                    } else {
-                        self.nickNameSeparatorAlert.isHidden = true
-                        self.nickNameSeparatorAlertImage.isHidden = true
-                        self.nextButton.isEnabled = true
-                    }
+                if text.contains(" ") {
+                    self.nickNameSeparatorAlert.isHidden = false
+                    self.nickNameSeparatorAlertImage.isHidden = false
                     
                 } else {
-                    self.nextButton.isEnabled = false
+                    self.nickNameSeparatorAlert.isHidden = true
+                    self.nickNameSeparatorAlertImage.isHidden = true
                 }
                 
             })
@@ -170,7 +193,7 @@ extension CreateAssistantProfileViewController {
         // 로딩 상태 처리
         viewModel.isLoading
             .subscribe(onNext: { [weak self] isLoading in
-                self?.nextButton.isEnabled = !isLoading
+                // 로딩 중일 때 버튼이 비활성화되는 로직은 Observable.combineLatest 쪽에서 처리함
                 // 로딩 인디케이터가 있다면 여기서 처리
             })
             .disposed(by: disposeBag)

--- a/SherlDog/Scene/User/HumanProfile/HumanProfileViewModel.swift
+++ b/SherlDog/Scene/User/HumanProfile/HumanProfileViewModel.swift
@@ -15,7 +15,7 @@ final class HumanProfileViewModel {
     let introduce = BehaviorRelay<String>(value: "")
     let image = BehaviorRelay<UIImage?>(value: nil)
     let saveResult = PublishSubject<Result<Void, Error>>()
-    let isLoading = BehaviorRelay<Bool>(value: false)
+    let isLoading = PublishRelay<Bool>()
 
     private let disposeBag = DisposeBag()
 

--- a/SherlDog/Scene/User/HumanProfile/SelectAvatarViewController.swift
+++ b/SherlDog/Scene/User/HumanProfile/SelectAvatarViewController.swift
@@ -121,6 +121,7 @@ extension SelectAvatarViewController {
         [collectionView, horizontalStackView]
             .forEach { view.addSubview($0) }
         
+        collectionView.backgroundColor = .textInverse
         collectionView.register(SelectAvatarCell.self, forCellWithReuseIdentifier: SelectAvatarCell.identifier)
         collectionView.register(PictureUploadRequestViewHeader.self,
                                 forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,

--- a/SherlDog/Scene/User/PetProfile/BreedTableViewCell.swift
+++ b/SherlDog/Scene/User/PetProfile/BreedTableViewCell.swift
@@ -9,6 +9,7 @@ import SnapKit
 
 class BreedTableViewCell: UITableViewCell {
     
+    private let selectedView = UIView()
     private let breedLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16, weight: .medium)
@@ -35,7 +36,8 @@ class BreedTableViewCell: UITableViewCell {
     
     private func setupCell() {
         backgroundColor = .clear
-        selectionStyle = .none
+        selectedView.backgroundColor = .keycolorDisabled
+        self.selectedBackgroundView = selectedView
         
         [breedLabel, arrowImageView].forEach {
             contentView.addSubview($0)


### PR DESCRIPTION
close #160 

## *⛳️ Work Description*

- 조수 프로필의 기본 아바타 선택 바텀시트,
  펫 프로필의 견종 선택 뷰의 selectedCell 다크모드 대응
- 조수 프로필도 펫 프로필과 마찬가지로 모든 정보를 입력해야 다음 버튼을 클릭할 수 있도록 설정했습니다.

## *📸 Screenshot*

| before | After | 
| -- | -- |
| <img src="https://github.com/user-attachments/assets/0411d073-fdc6-44c5-a900-01c9535ce364"  width="300"/> | <img src="https://github.com/user-attachments/assets/07604c74-e3c9-4c39-9d13-d1b31fa83843"  width="300"/> |
| <img src="https://github.com/user-attachments/assets/3e38c522-c196-47b4-99c8-e5b9b01518ec"  width="300"/> | <img src="https://github.com/user-attachments/assets/b08ee979-3b0d-4c62-8be6-0e0684e9dd97"  width="300"/> |
| <img src=""  width="300"/> | <img src="https://github.com/user-attachments/assets/6accce78-df52-4bed-97fe-ef9c644c17d0"  width="300"/> |


## *📢 To Reviewers*

- HumanProfileViewModel의 isLoading 프로퍼티 타입을 BehaviorRelay에서 PublishRelay로 변경했습니다.
- selectedCell의 백그라운드 색은 지정된 게 없어서 임의로 .keycolorDisabled 로 지정했습니다. 변경 필요하다면 말씀해주세요.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
