### PR TITLE
[Fix] 펫프로필 중복 저장되는 문제

### DIFF
--- a/SherlDog/Scene/User/PetProfile/RegistrationViewController.swift
+++ b/SherlDog/Scene/User/PetProfile/RegistrationViewController.swift
@@ -100,9 +100,15 @@ class RegistrationViewController: UIViewController {
             } else {
                 self?.registCompletButton.isEnabled = false
             }
-               
         })
         .disposed(by: disposeBag)
+        
+        viewModel.isLoading
+            .subscribe(onNext: { [weak self] isLoading in
+                self?.registCompletButton.isEnabled = !isLoading
+                // 인디케이터 활성, 비활성은 여기서 진행
+            })
+            .disposed(by: disposeBag)
         
         self.registrationButton.rx.tap
             .subscribe(onNext: { [weak self]  _ in

--- a/SherlDog/Scene/User/PetProfile/RegistrationViewModel.swift
+++ b/SherlDog/Scene/User/PetProfile/RegistrationViewModel.swift
@@ -24,9 +24,12 @@ class RegistrationViewModel {
     let selectedGender = BehaviorRelay<String>(value: "")
     let isNeutered = BehaviorRelay<Bool?>(value: nil)
     let introduce = BehaviorRelay<String>(value: "")
+    let isLoading = PublishRelay<Bool>()
     let saveResult = PublishSubject<Result<Void, Error>>()
 
     func uploadImageAndSaveProfile(image: UIImage) {
+        self.isLoading.accept(true)
+        
         let newDocRef = FirestoreManager.shared.db.collection("PetProfile").document()
         let petProfileID = newDocRef.documentID
         self.imageDocumentId = petProfileID
@@ -38,6 +41,7 @@ class RegistrationViewModel {
                 self?.savePetProfile(petProfileID: petProfileID)
             case .failure(let error):
                 self?.saveResult.onNext(.failure(error))
+                self?.isLoading.accept(false)
             }
         }
     }
@@ -78,9 +82,11 @@ class RegistrationViewModel {
             onCompleted: { [weak self] in
                 UserDefaults.standard.set(petProfileID, forKey: "newPetProfileId")
                 self?.saveResult.onNext(.success(()))
+                self?.isLoading.accept(false)
             },
             onError: { [weak self] error in
                 self?.saveResult.onNext(.failure(error))
+                self?.isLoading.accept(false)
             }
         )
         .disposed(by: disposeBag)


### PR DESCRIPTION
close #162 

## *⛳️ Work Description*

- 펫 프로필이 중복 업로드 될 수 있는 문제 수정

## *📸 Screenshot*

| before | After | 
| -- | -- |
|  | <img src="https://github.com/user-attachments/assets/14cb4688-c5ed-4591-9f4e-5d86513c003f"  width="300"/> |

## *📢 To Reviewers*

- RegistrationViewModel에 PublishRelay< Bool>타입 프로퍼티 isLoading을 추가했습니다.
- 이후 인디케이터를 생성하게 된다면
  RegistrationViewController의 bind() 메서드의 viewModel.isLoading 바인드 부분에서 사용하시면 됩니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
