### PR TITLE
[Fix] 멍탐정카드 사진 cornerRadius 추가, 단서 남기기 뷰 닫기 버튼 추가

### DIFF
--- a/SherlDog/Application/SceneDelegate.swift
+++ b/SherlDog/Application/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // 로그인 상태 확인 후 초기 화면 결정
        let initialViewController = determineInitialViewController()
         
-        window.rootViewController = BottomTabBarController()
+        window.rootViewController = initialViewController
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/SherlDog/Application/SceneDelegate.swift
+++ b/SherlDog/Application/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // 로그인 상태 확인 후 초기 화면 결정
        let initialViewController = determineInitialViewController()
         
-        window.rootViewController = initialViewController
+        window.rootViewController = BottomTabBarController()
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/SherlDog/Scene/HomeTap/Clue/ClueInputViewController.swift
+++ b/SherlDog/Scene/HomeTap/Clue/ClueInputViewController.swift
@@ -12,6 +12,7 @@ import RxCocoa
 
 class ClueInputViewController: UIViewController {
     private let clueLabel = UILabel()
+    private let cancelButton = UIButton()
     private let imageView = UIImageView()
     private let textView = UITextView()
     private let registerButton = UIButton()
@@ -48,6 +49,8 @@ class ClueInputViewController: UIViewController {
         clueLabel.text = "단서 남기기"
         clueLabel.font = .highlight3
         clueLabel.textColor = .textPrimary
+        
+        cancelButton.setImage(.modalExit, for: .normal)
 
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
@@ -83,13 +86,18 @@ class ClueInputViewController: UIViewController {
         countLabel.font = .alert2
         countLabel.textColor = .gray400
         
-        [clueLabel, imageView, textView, registerButton, countLabel].forEach { view.addSubview($0) }
+        [clueLabel, cancelButton, imageView, textView, registerButton, countLabel].forEach { view.addSubview($0) }
     }
     
     private func setupConstraints() {
         clueLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(16)
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(26)
+        }
+        
+        cancelButton.snp.makeConstraints {
+            $0.top.equalTo(clueLabel)
+            $0.trailing.equalToSuperview().inset(16)
         }
         
         imageView.snp.makeConstraints {
@@ -125,6 +133,12 @@ class ClueInputViewController: UIViewController {
                       let mainView = self.view.window?.rootViewController else { return }
                 mainView.dismiss(animated: true)
             }
+            .disposed(by: disposeBag)
+        
+        cancelButton.rx.tap
+            .bind(onNext: { [weak self] in
+                self?.dismiss(animated: true)
+            })
             .disposed(by: disposeBag)
     }
 

--- a/SherlDog/Scene/User/PetProfile/DetectiveCardCollectionViewCell.swift
+++ b/SherlDog/Scene/User/PetProfile/DetectiveCardCollectionViewCell.swift
@@ -56,6 +56,6 @@ class DetectiveCardCollectionViewCell: UICollectionViewCell {
         }
         
         // 프로필 이미지 설정
-        detectiveCardView.detectivePhotoImageView.backgroundColor = .gray400
+//        detectiveCardView.detectivePhotoImageView.backgroundColor = .gray400
     }
 }

--- a/SherlDog/Scene/User/PetProfile/DetectiveCardCollectionViewCell.swift
+++ b/SherlDog/Scene/User/PetProfile/DetectiveCardCollectionViewCell.swift
@@ -54,8 +54,5 @@ class DetectiveCardCollectionViewCell: UICollectionViewCell {
                 self?.detectiveCardView.detectivePhotoImageView.image = image
             }
         }
-        
-        // 프로필 이미지 설정
-//        detectiveCardView.detectivePhotoImageView.backgroundColor = .gray400
     }
 }

--- a/SherlDog/Scene/User/PetProfile/DetectiveCardView.swift
+++ b/SherlDog/Scene/User/PetProfile/DetectiveCardView.swift
@@ -77,7 +77,8 @@ class DetectiveCardView: UIView {
         detectiveNumber.font = UIFont.cardTitle
         detectiveNumber.textColor = .textPrimary
         
-        detectivePhotoImageView.backgroundColor = .gray400
+        detectivePhotoImageView.layer.cornerRadius = 4
+        detectivePhotoImageView.clipsToBounds = true
         
         detectiveNameLabel.text = "탐정명"
         detectiveNameLabel.verticalAlignment = .top


### PR DESCRIPTION
close #178 

## *⛳️ Work Description*

- 멍탐정 카드 사진의 cornerRadius값을 추가했습니다.
- 단서 남기기 뷰에 닫기(X) 버튼 추가했습니다.

## *📸 Screenshot*

| before | After | 
| -- | -- |
| <img src="https://github.com/user-attachments/assets/656d1a61-9771-45ab-b917-859a888754ef"  width="300"/> | <img src="https://github.com/user-attachments/assets/3651d945-3dbb-4646-a6c0-85d12e820a9f"  width="300"/> |
| <img src=""  width="300"/> | <img src="https://github.com/user-attachments/assets/ccce5ac1-2022-46c1-a67a-c6ed300f6d96"  width="300"/> |

## *📢 To Reviewers*

- 첫 번째 사진에 검은 여백이 보이는 건 아바타 이미지의 문제 같습니다.
  다른 사진으로 하면 검은 여백 없이 잘 출력됩니다.
- 디자이너님께 아바타 이미지 수정요청 드렸습니다.
- 이미지 뷰의 백그라운드 컬러 설정은 카메라 연동 이전에 테스트용으로 작성하신 걸로 판단해 삭제했습니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
