### PR TITLE
[Fix] #184 - 수사시작 버튼 안눌렀는데도 경로 그려지는 부분수정, 현위치 아이콘이 처음 좌표로 고정되는 버그 수정

### DIFF
--- a/SherlDog/Scene/HomeTap/Main/MainViewController.swift
+++ b/SherlDog/Scene/HomeTap/Main/MainViewController.swift
@@ -171,7 +171,20 @@ class MainViewController: UIViewController {
         viewModel.fullSideOfCourse
             .subscribe(onNext: { [weak self] fullSide in
                 guard let self else { return }
-                
+
+                // If not enough path, show alert and return
+                if fullSide.isEmpty {
+                    let alert = AlertManager(
+                        message: "기록된 경로가 부족해요!",
+                        subMessage: "5미터 이상 이동 시 기록이 가능해요.",
+                        buttonTitles: ["확인"],
+                        buttonActions: [nil]
+                    )
+                    self.present(alert, animated: true)
+                    self.setInvestigation(active: false)
+                    return
+                }
+
                 // WalkendModalViewController의 imageView에 맞게 들어가도록 예측한 값.
                 /*
                  top 25추정 + 박스사이즈(약 120추정) + 15 + 박스사이즈(약 150추정) + 60 + 라벨사이즈(약 24추정) + 75 = 469
@@ -561,6 +574,9 @@ extension MainViewController: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let location = locations.last else { return }
         
+        let coord = location.coordinate
+           mapView.locationOverlay.location = NMGLatLng(lat: coord.latitude, lng: coord.longitude)
+
         // 앱 처음 시작 시 한 번만 현재 위치로 카메라 이동
         if !hasSetInitialCamera {
             let coord = location.coordinate

--- a/SherlDog/Scene/HomeTap/Main/MainViewModel.swift
+++ b/SherlDog/Scene/HomeTap/Main/MainViewModel.swift
@@ -39,7 +39,12 @@ final class MainViewModel {
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
                 self.isTracking.accept(false)
-                self.fullSideOfCourse.accept(self.fetchFullSide())
+                let coords = self.coordinates.value
+                if coords.count < 2 {
+                    self.fullSideOfCourse.accept(NMGLatLngBounds())
+                } else {
+                    self.fullSideOfCourse.accept(self.fetchFullSide())
+                }
             })
             .disposed(by: disposeBag)
     }
@@ -61,11 +66,11 @@ final class MainViewModel {
                 if let prev = previous {
                     let distance = CLLocation(latitude: prev.latitude, longitude: prev.longitude)
                         .distance(from: CLLocation(latitude: current.latitude, longitude: current.longitude))
-
-                    if distance >= 10 && distance < 50 {
+                    
+                    if self.isTracking.value && distance >= 5 && distance < 50 {
                         self.coordinates.accept(self.coordinates.value + [current])
                     }
-                } else {
+                } else if self.isTracking.value {
                     self.coordinates.accept(self.coordinates.value + [current])
                 }
             })


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

- 수사시작 버튼 안눌렀는데도 경로 그려지는 부분 수정
- 현위치 아이콘이 처음 좌표로 고정되는 버그 수정
- 좌표 배열이 전달 안됐을때(가만히 있을때) 기록된 경로가 부족하다고 alert 생성

## *📸 Screenshot*

(before)

https://github.com/user-attachments/assets/0d7d6986-a1fa-4a69-864a-b9d249731b0c

(after)


https://github.com/user-attachments/assets/67c44d5f-4052-440c-b475-dbaf3354312c


## *📢 To Reviewers*

- MainViewModel을 수정 한 이후 "수사 종료" 버튼을 누르면 앱이 크래쉬가 나는 부작용이 생김
- 수사중일때 좌표가 추가되게 해서 경로가 그려지게 수정 -> 하지만 가만히 있으면 좌표 배열에 nil값이 전달되서 크래쉬 발생
- 기록된 경로 없다고 alert를 띄운후 다시 "수사 시작" 버튼이 나오게 플로우를 생성

## *✅ Checklist*
