### PR TITLE
[Feat] 마이페이지 수사 기록의 버튼 기능 구현

### DIFF
--- a/SherlDog/Firebase/FireStoreManager.swift
+++ b/SherlDog/Firebase/FireStoreManager.swift
@@ -84,6 +84,29 @@ extension FirestoreManager {
         }
     }
     
+    /// 원하는 문서의 도큐멘트 아이디 가져오기
+    func findDocumentId(
+        collection: String,
+        whereField field: String,
+        isEqualTo value: Any
+    ) -> Single<[String]> {
+        return Single.create { [weak self] single in
+            self?.db.collection(collection)
+                .whereField(field, isEqualTo: value)
+                .getDocuments { snapshot, error in
+                    if let error = error {
+                        single(.failure(error))
+                    } else if let snapshot = snapshot {
+                        let items: [String] = snapshot.documents.compactMap { $0.documentID }
+                        single(.success(items))
+                    } else {
+                        single(.failure(FirestoreError.noData))
+                    }
+                }
+            return Disposables.create()
+        }
+    }
+    
     /// 컬렉션 전체 읽기
     func fetchCollection<T: Decodable>(collection: String, type: T.Type) -> Single<[T]> {
         return Single.create { [weak self] single in

--- a/SherlDog/Firebase/FirebaseImageManager.swift
+++ b/SherlDog/Firebase/FirebaseImageManager.swift
@@ -2,6 +2,7 @@ import UIKit
 import Firebase
 import FirebaseStorage
 import FirebaseAuth
+import RxSwift
 
 class FirebaseImageManager {
     static let shared = FirebaseImageManager()
@@ -123,6 +124,25 @@ class FirebaseImageManager {
             }
         }
     }
+    
+    // MARK: - 이미지 삭제
+    func deleteImage(urlString: String) -> Completable {
+        return Completable.create { completable in
+            let storageRef = Storage.storage().reference(forURL: urlString)
+            
+            storageRef.delete { error in
+                if let error = error {
+                    completable(.error(error))
+                } else {
+                    completable(.completed)
+                }
+            }
+            
+            return Disposables.create()
+        }
+        
+    }
+
 }
 
 // MARK: - UploadType

--- a/SherlDog/Scene/HomeTap/Investigation/DataTrackingViewModel.swift
+++ b/SherlDog/Scene/HomeTap/Investigation/DataTrackingViewModel.swift
@@ -23,8 +23,8 @@ class DataTrackingViewModel {
     let endDate = BehaviorRelay<Date?>(value: nil)
     let duration = BehaviorRelay(value: "")
     let trackingActive = BehaviorRelay<Bool>(value: false)
-    let fullScreenImage = BehaviorRelay(value: UIImage())
-    let capturedImage = BehaviorRelay(value: UIImage())
+    let fullScreenImage = PublishRelay<UIImage>()
+    let capturedImage = PublishRelay<UIImage>()
     let invLogListViewSendImage = BehaviorRelay(value: UIImage())
     
     let fetchResult = BehaviorRelay<WalkResult?>(value: nil)

--- a/SherlDog/Scene/HomeTap/Investigation/DataTrackingViewModel.swift
+++ b/SherlDog/Scene/HomeTap/Investigation/DataTrackingViewModel.swift
@@ -33,7 +33,7 @@ class DataTrackingViewModel {
     private let pedometer = CMPedometer()
     
     init() {
-        
+        transform()
     }
     
     private func transform() {
@@ -43,7 +43,7 @@ class DataTrackingViewModel {
                       let userId = Auth.auth().currentUser?.uid else { return }
                 let dateFormatter = DateFormatter()
                 dateFormatter.dateFormat = "yyyy-MM-dd"
-                let date = dateFormatter.date(from: result.date)
+                guard let date = dateFormatter.date(from: result.date) else { return }
                 
                 self.numberOfSteps.accept(result.steps)
                 self.distance.accept(result.distance)
@@ -56,6 +56,23 @@ class DataTrackingViewModel {
                     
                     self.invLogListViewSendImage.accept(image)
                 }
+            })
+            .disposed(by: disposeBag)
+        
+        Observable
+            .combineLatest(startDate, endDate)
+            .compactMap { start, end -> String? in
+                guard let start = start, let end = end else { return nil }
+                let interval = Int(end.timeIntervalSince(start))
+                let hours = interval / 3600
+                let minutes = (interval % 3600) / 60
+                let seconds = interval % 60
+                return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+            }
+            .bind(onNext: { [weak self] result in
+                guard let self else { return }
+                
+                duration.accept(result)
             })
             .disposed(by: disposeBag)
     }
@@ -103,11 +120,10 @@ class DataTrackingViewModel {
         }()
         
         let userId = Auth.auth().currentUser?.uid ?? "anonymous"
-        let profileIds = selectedProfiles.map { $0.petProfileId }
         
         let newWalkResult = WalkResult(
             userId: userId,
-            petProfileId: profileIds,
+            petProfileId: selectedProfiles,
             date: dateString,
             distance: distance.value,
             duration: duration.value,

--- a/SherlDog/Scene/HomeTap/Investigation/WalkEndModalViewController.swift
+++ b/SherlDog/Scene/HomeTap/Investigation/WalkEndModalViewController.swift
@@ -97,7 +97,8 @@ class WalkEndModalViewController : UIViewController {
         
         self.DataTrackingVM.fullScreenImage
             .bind(onNext: { [weak self] image in
-                guard let self else { return }
+                guard let self,
+                      self.DataTrackingVM.fetchResult.value == nil else { return }
                 
                 DispatchQueue.main.async {
                     self.mapImageView.image = image
@@ -110,7 +111,8 @@ class WalkEndModalViewController : UIViewController {
         
         self.DataTrackingVM.capturedImage
             .bind(onNext: { [weak self] image in
-                guard let self else { return }
+                guard let self,
+                      self.DataTrackingVM.fetchResult.value == nil else { return }
                 
                 self.DataTrackingVM.saveWalkResultCapturedImage(
                     image: image,
@@ -121,7 +123,8 @@ class WalkEndModalViewController : UIViewController {
         
         self.DataTrackingVM.saveResult
             .subscribe(onNext: { [weak self] result in
-                guard let self else { return }
+                guard let self,
+                      self.DataTrackingVM.fetchResult.value == nil else { return }
                 
                 switch result {
                 case .success():
@@ -140,8 +143,22 @@ class WalkEndModalViewController : UIViewController {
             })
             .disposed(by: disposeBag)
         
+        self.DataTrackingVM.fetchResult
+            .bind(onNext: { [weak self] result in
+                guard let self, let result else { return }
+                
+                self.selectedPetProfiles = result.petProfileId
+                self.setPetImages()
+            })
+            .disposed(by: disposeBag)
+        
         self.DataTrackingVM.invLogListViewSendImage
-            .bind(to: self.mapImageView.rx.image)
+            .bind(onNext: { [weak self] image in
+                guard let self,
+                      self.DataTrackingVM.fetchResult.value != nil else { return }
+                
+                self.mapImageView.image = image
+            })
             .disposed(by: disposeBag)
         
         self.walkShareButton.rx.tap
@@ -171,21 +188,14 @@ class WalkEndModalViewController : UIViewController {
             .bind(to: distanceContentLabel.rx.text)
             .disposed(by: disposeBag)
         
-        Observable
-            .combineLatest(DataTrackingVM.startDate, DataTrackingVM.endDate)
-            .compactMap { start, end -> String? in
-                guard let start = start, let end = end else { return nil }
-                let interval = Int(end.timeIntervalSince(start))
-                let hours = interval / 3600
-                let minutes = (interval % 3600) / 60
-                let seconds = interval % 60
-                return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+        DataTrackingVM.endDate
+            .map {
+                guard let endDate = $0 else { return "date" }
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy/MM/dd"
+                return dateFormatter.string(from: endDate)
             }
-            .bind(onNext: { [weak self] duration in
-                guard let self else { return }
-                
-                self.DataTrackingVM.duration.accept(duration)
-            })
+            .bind(to: self.todayLabel.rx.text)
             .disposed(by: disposeBag)
         
         DataTrackingVM.duration
@@ -366,6 +376,53 @@ class WalkEndModalViewController : UIViewController {
         dogImagesStack.spacing = -20
         dogImagesStack.alignment = .center
         dogImagesStack.backgroundColor = .clear
+        // 선택된 강아지들의 실제 이미지 사용
+        setPetImages()
+        
+        mapImageView.image = UIImage(named: "mapPolaroid")
+        mapImageView.contentMode = .scaleAspectFill
+        mapImageView.clipsToBounds = true
+        mapImageView.backgroundColor = .clear
+        
+//        walkShareButton.setTitle("멍탐정과 남긴 단서", for: .normal)
+//        walkShareButton.titleLabel?.font = UIFont.highlight4
+//        walkShareButton.setTitleColor(UIColor(named: "textInverse"), for: .normal)
+//        walkShareButton.backgroundColor = UIColor(named: "keycolorPrimary3")
+//        walkShareButton.layer.cornerRadius = 6
+        
+        distanceStack.axis = .vertical
+        distanceStack.spacing = 4
+        distanceStack.alignment = .leading
+        distanceStack.addArrangedSubview(distanceLabel)
+        distanceStack.addArrangedSubview(distanceContentLabel)
+        distanceStack.backgroundColor = .clear
+        
+        timeStack.axis = .vertical
+        timeStack.spacing = 4
+        timeStack.alignment = .leading
+        timeStack.addArrangedSubview(timeLabel)
+        timeStack.addArrangedSubview(timeContentLabel)
+        timeStack.backgroundColor = .clear
+        
+        stepCountStack.axis = .vertical
+        stepCountStack.spacing = 4
+        stepCountStack.alignment = .fill
+        stepCountStack.addArrangedSubview(stepLabelWrapper)
+        stepCountStack.addArrangedSubview(stepCountContentLabel)
+        stepCountStack.backgroundColor = .clear
+        
+        infoStack.axis = .horizontal
+        infoStack.distribution = .fillEqually
+        infoStack.addArrangedSubview(distanceStack)
+        infoStack.addArrangedSubview(timeStack)
+        infoStack.addArrangedSubview(stepCountStack)
+        infoStack.backgroundColor = .clear
+        
+        closeButton.setImage(UIImage(named: "modalExit"), for: .normal)
+        closeButton.contentMode = .scaleAspectFit
+    }
+    
+    private func setPetImages() {
         dogImagesStack.arrangedSubviews.forEach {
             dogImagesStack.removeArrangedSubview($0)
             $0.removeFromSuperview()
@@ -411,48 +468,6 @@ class WalkEndModalViewController : UIViewController {
                 dogImagesStack.addArrangedSubview(imageView)
             }
         }
-        
-        mapImageView.image = UIImage(named: "mapPolaroid")
-        mapImageView.contentMode = .scaleAspectFill
-        mapImageView.clipsToBounds = true
-        mapImageView.backgroundColor = .clear
-        
-//        walkShareButton.setTitle("멍탐정과 남긴 단서", for: .normal)
-//        walkShareButton.titleLabel?.font = UIFont.highlight4
-//        walkShareButton.setTitleColor(UIColor(named: "textInverse"), for: .normal)
-//        walkShareButton.backgroundColor = UIColor(named: "keycolorPrimary3")
-//        walkShareButton.layer.cornerRadius = 6
-        
-        distanceStack.axis = .vertical
-        distanceStack.spacing = 4
-        distanceStack.alignment = .leading
-        distanceStack.addArrangedSubview(distanceLabel)
-        distanceStack.addArrangedSubview(distanceContentLabel)
-        distanceStack.backgroundColor = .clear
-        
-        timeStack.axis = .vertical
-        timeStack.spacing = 4
-        timeStack.alignment = .leading
-        timeStack.addArrangedSubview(timeLabel)
-        timeStack.addArrangedSubview(timeContentLabel)
-        timeStack.backgroundColor = .clear
-        
-        stepCountStack.axis = .vertical
-        stepCountStack.spacing = 4
-        stepCountStack.alignment = .fill
-        stepCountStack.addArrangedSubview(stepLabelWrapper)
-        stepCountStack.addArrangedSubview(stepCountContentLabel)
-        stepCountStack.backgroundColor = .clear
-        
-        infoStack.axis = .horizontal
-        infoStack.distribution = .fillEqually
-        infoStack.addArrangedSubview(distanceStack)
-        infoStack.addArrangedSubview(timeStack)
-        infoStack.addArrangedSubview(stepCountStack)
-        infoStack.backgroundColor = .clear
-        
-        closeButton.setImage(UIImage(named: "modalExit"), for: .normal)
-        closeButton.contentMode = .scaleAspectFit
     }
     
     private func configureUI() {

--- a/SherlDog/Scene/HomeTap/Investigation/WalkResultModel.swift
+++ b/SherlDog/Scene/HomeTap/Investigation/WalkResultModel.swift
@@ -10,7 +10,7 @@ import FirebaseFirestore
 
 struct WalkResult: Codable {
     let userId: String
-    let petProfileId: [String]
+    let petProfileId: [PetProfile]
     let date: String
     let distance: Double
     let duration: String

--- a/SherlDog/Scene/HomeTap/Main/MainViewController.swift
+++ b/SherlDog/Scene/HomeTap/Main/MainViewController.swift
@@ -275,11 +275,15 @@ class MainViewController: UIViewController {
                         let image = renderer.image { ctx in
                             window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
                         }
-                        self.DataTrackingVM.fullScreenImage.accept(image)
+                        
+                        let selectedProfiles = self.requestViewModel.output.selectedPetProfiles.value
+                        let walkEndModal = WalkEndModalViewController(viewModel: self.DataTrackingVM, selectedProfiles: selectedProfiles)
+                        let nav = UINavigationController(rootViewController: walkEndModal)
+                        nav.modalPresentationStyle = .overFullScreen
+                        self.present(nav, animated: true) {
+                            self.DataTrackingVM.fullScreenImage.accept(image)
+                        }
                     }
-                    
-                    // 선택된 멍탐정 정보 연동된 WalkEndModal띄우는 메서드
-                    self.showWalkEndModal()
                     
                     self.pathOverlays.forEach { $0.mapView = nil }
                     self.pathOverlays.removeAll()
@@ -453,13 +457,13 @@ class MainViewController: UIViewController {
         statusLabel.text = image.count > 1 ? "멍탐정들과 함께 수사 중" : "멍탐정과 함께 수사 중"
     }
     
-    private func showWalkEndModal() {
-        let selectedProfiles = requestViewModel.output.selectedPetProfiles.value
-        let walkEndModal = WalkEndModalViewController(viewModel: DataTrackingVM, selectedProfiles: selectedProfiles)
-        let nav = UINavigationController(rootViewController: walkEndModal)
-        nav.modalPresentationStyle = .overFullScreen
-        present(nav, animated: true)
-    }
+//    private func showWalkEndModal() {
+//        let selectedProfiles = requestViewModel.output.selectedPetProfiles.value
+//        let walkEndModal = WalkEndModalViewController(viewModel: DataTrackingVM, selectedProfiles: selectedProfiles)
+//        let nav = UINavigationController(rootViewController: walkEndModal)
+//        nav.modalPresentationStyle = .overFullScreen
+//        present(nav, animated: true)
+//    }
     
     private func configureInitialVisibility() {
         // 시작 시 상태 뷰 및 버튼 숨김

--- a/SherlDog/Scene/MyPageTap/InvLogListViewController.swift
+++ b/SherlDog/Scene/MyPageTap/InvLogListViewController.swift
@@ -50,6 +50,12 @@ extension InvLogListViewController {
         self.viewModel.output.cellData
             .bind(to: self.collectionView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
+        
+        self.viewModel.output.deleteCompleted
+            .bind(onNext: { [weak self] in
+                // todo: 완료 처리
+            })
+            .disposed(by: disposeBag)
     }
     
     private func inputBind() {
@@ -128,20 +134,30 @@ extension InvLogListViewController: InvLogListCellEventDelegate {
     func deleteButtonTapEvent(_ cell: UICollectionViewCell) {
         guard let indexPath = self.collectionView.indexPath(for: cell) else { return }
         
+        let alert = AlertManager(message: "수사일지를 삭제하시겠습니까?",
+                                 buttonTitles: ["취소", "확인"],
+                                 buttonActions: [nil, { [weak self] in
+            self?.viewModel.input.accept(.delete(indexPath))
+        }])
+        
+        self.present(alert, animated: true)
+        
         print("\(indexPath.row)번 셀 삭제")
     }
     
     func showButtonTapEvent(_ cell: UICollectionViewCell) {
         guard let indexPath = self.collectionView.indexPath(for: cell) else { return }
         
-//        let originalData = self.viewModel.originalData[indexPath.row]
-//        let walkResultViewModel = DataTrackingViewModel()
-//        let walkEndView = WalkEndModalViewController(viewModel: walkResultViewModel)
-//        
-//        walkResultViewModel.fetchResult.accept(originalData)
-//        
-//        self.present(walkEndView, animated: true)
-        print("\(indexPath.row)번 셀 수사일지 보기")
+        let originalData = self.viewModel.originalData[indexPath.row]
+        
+        let walkResultViewModel = DataTrackingViewModel()
+        let walkEndView = WalkEndModalViewController(viewModel: walkResultViewModel)
+        let nav = UINavigationController(rootViewController: walkEndView)
+        nav.modalPresentationStyle = .overFullScreen
+        
+        walkResultViewModel.fetchResult.accept(originalData)
+        
+        self.present(nav, animated: true)
     }
     
     

--- a/SherlDog/Scene/MyPageTap/InvLogListViewController.swift
+++ b/SherlDog/Scene/MyPageTap/InvLogListViewController.swift
@@ -41,6 +41,12 @@ class InvLogListViewController: UIViewController {
         inputBind()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.viewModel.input.accept(.viewWillAppear)
+    }
+    
 }
 
 // MARK: - Method
@@ -53,7 +59,7 @@ extension InvLogListViewController {
         
         self.viewModel.output.deleteCompleted
             .bind(onNext: { [weak self] in
-                // todo: 완료 처리
+                print("삭제 완료") // todo: 완료 처리
             })
             .disposed(by: disposeBag)
     }
@@ -141,8 +147,6 @@ extension InvLogListViewController: InvLogListCellEventDelegate {
         }])
         
         self.present(alert, animated: true)
-        
-        print("\(indexPath.row)번 셀 삭제")
     }
     
     func showButtonTapEvent(_ cell: UICollectionViewCell) {

--- a/SherlDog/Scene/MyPageTap/InvLogListViewModel.swift
+++ b/SherlDog/Scene/MyPageTap/InvLogListViewModel.swift
@@ -19,10 +19,15 @@ class InvLogListViewModel {
     typealias InvLogListDataSource = SectionModel<String, WalkResultToList>
     
     private let disposeBag = DisposeBag()
+    private var data = [WalkResultToList]() {
+        didSet {
+            self.output.cellData.accept([InvLogListDataSource(model: "", items: self.data)])
+        }
+    }
     var originalData = [WalkResult]()
-    private var data = [WalkResultToList]()
     
     enum Input {
+        case viewWillAppear
         case delete(IndexPath)
     }
     
@@ -37,7 +42,6 @@ class InvLogListViewModel {
     // MARK: - Initialize
     init() {
         transform()
-        fetchWalkResultData()
     }
     
 }
@@ -51,6 +55,9 @@ extension InvLogListViewModel {
                 guard let self else { return }
                 
                 switch input {
+                case .viewWillAppear:
+                    self.fetchWalkResultData()
+                    
                 case .delete(let index):
                     self.deleteWalkResultData(at: index)
                 }
@@ -61,6 +68,7 @@ extension InvLogListViewModel {
     private func fetchWalkResultData() {
         guard let userId = Auth.auth().currentUser?.uid else { return }
         self.data = []
+        self.originalData = []
         
         FirestoreManager.shared.fetchDocuments(collection: "WalkResult",
                                                whereField: "userId",
@@ -73,19 +81,27 @@ extension InvLogListViewModel {
                 self.originalData.append($0)
                 self.data.append(WalkResultToList(from: $0))
             }
-            
-            self.output.cellData.accept([InvLogListDataSource(model: "", items: self.data)])
         })
         .disposed(by: disposeBag)
     }
     
     private func deleteWalkResultData(at indexPath: IndexPath) {
-        self.originalData[indexPath.row]
-        
-        FirestoreManager.shared.deleteDocument(collection: "WalkResult",
-                                               documentId: "") // todo: 도큐먼트 아이디,,?
+        FirestoreManager.shared.findDocumentId(collection: "WalkResult",
+                                               whereField: "walkingPathImage",
+                                               isEqualTo: self.originalData[indexPath.row].walkingPathImage)
+        .flatMapCompletable { documentId in
+            guard let id = documentId.first else { return Completable.error(FirestoreError.noData) }
+            
+            return FirestoreManager.shared.deleteDocument(collection: "WalkResult", documentId: id)
+                .andThen(FirebaseImageManager.shared.deleteImage(urlString: self.originalData[indexPath.row].walkingPathImage))
+        }
         .subscribe(onCompleted: { [weak self] in
-            self?.output.deleteCompleted.accept(())
+            guard let self else { return }
+            
+            self.data.remove(at: indexPath.row)
+            self.originalData.remove(at: indexPath.row)
+            
+            self.output.deleteCompleted.accept(())
         })
         .disposed(by: disposeBag)
     }

--- a/SherlDog/Scene/MyPageTap/InvLogListViewModel.swift
+++ b/SherlDog/Scene/MyPageTap/InvLogListViewModel.swift
@@ -23,11 +23,12 @@ class InvLogListViewModel {
     private var data = [WalkResultToList]()
     
     enum Input {
-        
+        case delete(IndexPath)
     }
     
     struct Output {
         let cellData = BehaviorRelay<[InvLogListDataSource]>(value: [])
+        let deleteCompleted = PublishRelay<Void>()
     }
     
     let input = PublishRelay<Input>()
@@ -45,7 +46,16 @@ class InvLogListViewModel {
 extension InvLogListViewModel {
     
     private func transform() {
-        
+        self.input
+            .bind(onNext: { [weak self] input in
+                guard let self else { return }
+                
+                switch input {
+                case .delete(let index):
+                    self.deleteWalkResultData(at: index)
+                }
+            })
+            .disposed(by: disposeBag)
     }
     
     private func fetchWalkResultData() {
@@ -65,6 +75,17 @@ extension InvLogListViewModel {
             }
             
             self.output.cellData.accept([InvLogListDataSource(model: "", items: self.data)])
+        })
+        .disposed(by: disposeBag)
+    }
+    
+    private func deleteWalkResultData(at indexPath: IndexPath) {
+        self.originalData[indexPath.row]
+        
+        FirestoreManager.shared.deleteDocument(collection: "WalkResult",
+                                               documentId: "") // todo: 도큐먼트 아이디,,?
+        .subscribe(onCompleted: { [weak self] in
+            self?.output.deleteCompleted.accept(())
         })
         .disposed(by: disposeBag)
     }


### PR DESCRIPTION
close #201 

## *⛳️ Work Description*

- 수사일지 보기, 삭제 버튼 기능 구현
- FireStoreManager에 도큐먼트 아이디를 찾는 메서드 추가
- FirebaseImageManager에 이미지를 삭제하는 메서드 추가

## *📸 Screenshot*

| before | After | 
| -- | -- |
|  | <img src="https://github.com/user-attachments/assets/29064b1b-7f7e-49bd-98c2-8ef830640dca"  width="300"/> |

## *📢 To Reviewers*

- DataTracking뷰모델의 이미지를 담는 BehaviorRelay 두개를 데이터 중복 업로드 문제 때문에 PublishRelay로 변경했습니다.
- WalkEnd뷰의 펫 이미지를 받아오는 부분을 메서드화했습니다
- WalkEnd뷰의 duration 계산 로직을 DataTracking뷰모델로 이동했습니다

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
