### PR TITLE
[Fix] 파이어스토리지 WalkResult 부분의 사진 파일이 덮어씌워지는 현상

### DIFF
--- a/SherlDog/Firebase/FirebaseImageManager.swift
+++ b/SherlDog/Firebase/FirebaseImageManager.swift
@@ -86,6 +86,43 @@ class FirebaseImageManager {
             }
         }
     }
+    // MARK: - WalkResult 이미지 업로드 (타임스탬프 포함)
+    func uploadWalkResultImage(_ image: UIImage, completion: @escaping (Result<String, Error>) -> Void) {
+        guard let imageData = image.jpegData(compressionQuality: 0.8) else {
+            completion(.failure(ImageError.invalidImageData))
+            return
+        }
+
+        guard let userId = Auth.auth().currentUser?.uid else {
+            completion(.failure(ImageError.invalidImageData))
+            return
+        }
+
+        // 타임스탬프로 유니크한 파일명 생성
+        let timestamp = Int(Date().timeIntervalSince1970)
+        let imagePath = "walkResult/\(userId)/walkResult_\(timestamp).jpg"
+        let imageRef = storageRef.child(imagePath)
+
+        let metadata = StorageMetadata()
+        metadata.contentType = "image/jpeg"
+
+        imageRef.putData(imageData, metadata: metadata) { _, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            imageRef.downloadURL { url, error in
+                if let error = error {
+                    completion(.failure(error))
+                } else if let downloadUrl = url?.absoluteString {
+                    completion(.success(downloadUrl))
+                } else {
+                    completion(.failure(ImageError.urlGenerationFailed))
+                }
+            }
+        }
+    }
     
     // MARK: - 이미지 다운로드
     func downloadImage(userId: String, type: UploadImageFor, completion: @escaping (UIImage?) -> Void) {

--- a/SherlDog/Scene/HomeTap/Investigation/DataTrackingViewModel.swift
+++ b/SherlDog/Scene/HomeTap/Investigation/DataTrackingViewModel.swift
@@ -97,7 +97,7 @@ class DataTrackingViewModel {
     }
     
     func saveWalkResultCapturedImage(image: UIImage, selectedProfiles: [PetProfile]) {
-        FirebaseImageManager.shared.uploadImage(image, type: .walkResult) { [weak self] result in
+        FirebaseImageManager.shared.uploadWalkResultImage(image) { [weak self] result in
             switch result {
             case .success(let urlString):
                 self?.imageURL.accept(urlString)


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

-파이어스토리지 WalkResult 부분의 사진 파일이 덮어씌워지는 현상 해결
## *📸 Screenshot*
![스크린샷 2025-06-27 오후 2 52 09](https://github.com/user-attachments/assets/bdacdeaf-e1c1-44c7-9b01-4d6ccfe4d6af)


- 리뷰어에게 하고 싶은 말

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
