### PR TITLE
[Fix] 파이어스토리지 clues 부분의 사진 파일이 덮어씌워지는 현상

### DIFF
--- a/SherlDog/Firebase/FirebaseImageManager.swift
+++ b/SherlDog/Firebase/FirebaseImageManager.swift
@@ -98,9 +98,45 @@ class FirebaseImageManager {
             return
         }
 
-        // 타임스탬프로 유니크한 파일명 생성
         let timestamp = Int(Date().timeIntervalSince1970)
         let imagePath = "walkResult/\(userId)/walkResult_\(timestamp).jpg"
+        let imageRef = storageRef.child(imagePath)
+
+        let metadata = StorageMetadata()
+        metadata.contentType = "image/jpeg"
+
+        imageRef.putData(imageData, metadata: metadata) { _, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            imageRef.downloadURL { url, error in
+                if let error = error {
+                    completion(.failure(error))
+                } else if let downloadUrl = url?.absoluteString {
+                    completion(.success(downloadUrl))
+                } else {
+                    completion(.failure(ImageError.urlGenerationFailed))
+                }
+            }
+        }
+    }
+    
+    // MARK: - Clue 이미지 업로드 (타임스탬프 포함)
+    func uploadClueImage(_ image: UIImage, completion: @escaping (Result<String, Error>) -> Void) {
+        guard let imageData = image.jpegData(compressionQuality: 0.8) else {
+            completion(.failure(ImageError.invalidImageData))
+            return
+        }
+
+        guard let userId = Auth.auth().currentUser?.uid else {
+            completion(.failure(ImageError.invalidImageData))
+            return
+        }
+
+        let timestamp = Int(Date().timeIntervalSince1970)
+        let imagePath = "clue/\(userId)/clue_\(timestamp).jpg"
         let imageRef = storageRef.child(imagePath)
 
         let metadata = StorageMetadata()

--- a/SherlDog/Scene/HomeTap/Clue/ClueDetailViewModel.swift
+++ b/SherlDog/Scene/HomeTap/Clue/ClueDetailViewModel.swift
@@ -98,6 +98,7 @@ final class ClueDetailViewModel {
         FirestoreManager.shared.fetchDocuments(collection: "clues",
                                                whereField: "userID",
                                                isEqualTo: userId,
+                                               orderBy: "date",
                                                type: ClueModel.self)
         .flatMap { [weak self] clue in
             let now = Date()

--- a/SherlDog/Scene/HomeTap/Clue/ClueInputViewController.swift
+++ b/SherlDog/Scene/HomeTap/Clue/ClueInputViewController.swift
@@ -21,7 +21,7 @@ class ClueInputViewController: UIViewController {
     private let registerButton = UIButton()
     private let countLabel = UILabel()
     private let placeholderLabel = UILabel()
-   
+    
     private let cameraViewModel: CameraViewModel
     private let disposeBag = DisposeBag()
     
@@ -57,7 +57,7 @@ class ClueInputViewController: UIViewController {
         clueLabel.textColor = .textPrimary
         
         cancelButton.setImage(.modalExit, for: .normal)
-
+        
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         imageView.layer.borderWidth = 1
@@ -71,7 +71,7 @@ class ClueInputViewController: UIViewController {
         textView.layer.borderWidth = 1
         textView.layer.cornerRadius = 6
         textView.textContainerInset = UIEdgeInsets(top: 16, left: 12, bottom: 0, right: 16)
-
+        
         placeholderLabel.text = "사건 파일에 남길 단서의 이야기를 적어주세요"
         placeholderLabel.font = .body3
         placeholderLabel.textColor = .keycolorDisabled
@@ -85,7 +85,7 @@ class ClueInputViewController: UIViewController {
         
         textView.delegate = self
         textView.returnKeyType = .done
-
+        
         registerButton.setTitle("단서 등록하기", for: .normal)
         registerButton.setTitleColor(.textInverse, for: .normal)
         registerButton.titleLabel?.font = .highlight4
@@ -115,7 +115,7 @@ class ClueInputViewController: UIViewController {
             $0.height.equalTo(imageView.snp.width).multipliedBy(1.1).priority(.low)
             $0.height.greaterThanOrEqualTo(100).priority(.low)
         }
-
+        
         textView.snp.makeConstraints{
             $0.top.equalTo(imageView.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview().inset(16)
@@ -126,7 +126,7 @@ class ClueInputViewController: UIViewController {
             $0.trailing.equalTo(textView.snp.trailing).inset(8)
             $0.bottom.equalTo(textView.snp.bottom).inset(8)
         }
-
+        
         registerButton.snp.makeConstraints {
             $0.top.equalTo(textView.snp.bottom).offset(32)
             $0.leading.trailing.equalToSuperview().inset(16)
@@ -134,7 +134,7 @@ class ClueInputViewController: UIViewController {
             $0.height.equalTo(52)
         }
     }
-
+    
     private func bindRegisterAction() {
         registerButton.rx.tap
             .bind { [weak self] in
@@ -148,7 +148,7 @@ class ClueInputViewController: UIViewController {
             })
             .disposed(by: disposeBag)
     }
-
+    
     private func bindTextView() {
         textView.rx.text.orEmpty
             .do(onNext: { [weak self] text in
@@ -185,7 +185,7 @@ class ClueInputViewController: UIViewController {
         registerButton.isEnabled = false
         registerButton.setTitle("저장 중...", for: .normal)
         
-        FirebaseImageManager.shared.uploadImage(image, type: .clue) { [weak self] result in
+        FirebaseImageManager.shared.uploadClueImage(image) { [weak self] result in
             switch result {
             case .success(let imageUrl):
                 self?.saveToFirestore(userId: userId, text: text, imageUrl: imageUrl)


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

- 파이어스토리지 clues 부분의 사진 파일이 덮어씌워지는 현상해결

## *📸 Screenshot*

![스크린샷 2025-06-27 오후 3 31 40](https://github.com/user-attachments/assets/084563e0-fbff-4917-bb20-0729a5e5e625)

## *📢 To Reviewers*

- 리뷰어에게 하고 싶은 말

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
