### PR TITLE
[Fix] 카메라 멈춤 현상 수정

### DIFF
--- a/SherlDog/Reusable/Camera/CameraViewController.swift
+++ b/SherlDog/Reusable/Camera/CameraViewController.swift
@@ -142,6 +142,18 @@ extension CameraViewController {
                 captureDevice.unlockForConfiguration()
             })
             .disposed(by: disposeBag)
+        
+        self.viewModel.output.cameraRestart
+            .bind(onNext: { [weak self] in
+                guard let self else { return }
+                
+                if !self.captureSession.isRunning {
+                    DispatchQueue.global().async {
+                        self.captureSession.startRunning()
+                    }
+                }
+            })
+            .disposed(by: disposeBag)
     }
     
     private func setupCamera() {

--- a/SherlDog/Reusable/Camera/CameraViewModel.swift
+++ b/SherlDog/Reusable/Camera/CameraViewModel.swift
@@ -22,6 +22,7 @@ class CameraViewModel {
         case captureImage(UIImage)
         case pinchGestureBegan(CGFloat)
         case pinchGestureChanged(CGFloat)
+        case dismiss
     }
     
     struct Output {
@@ -29,6 +30,7 @@ class CameraViewModel {
         let getCapture = PublishRelay<Void>()
         let capturedImage = BehaviorRelay<UIImage?>(value: nil)
         let pinchUpdate = PublishRelay<CGFloat>()
+        let cameraRestart = PublishRelay<Void>()
     }
     
     private let disposeBag = DisposeBag()
@@ -62,6 +64,9 @@ class CameraViewModel {
                 
             case .pinchGestureChanged(let value):
                 self.output.pinchUpdate.accept(self.zoomFactorOperation(value))
+                
+            case .dismiss:
+                self.output.cameraRestart.accept(())
             }
         }
         .disposed(by: disposeBag)

--- a/SherlDog/Scene/HomeTap/Clue/ClueInputViewController.swift
+++ b/SherlDog/Scene/HomeTap/Clue/ClueInputViewController.swift
@@ -144,7 +144,9 @@ class ClueInputViewController: UIViewController {
         
         cancelButton.rx.tap
             .bind(onNext: { [weak self] in
-                self?.dismiss(animated: true)
+                self?.dismiss(animated: true) {
+                    self?.cameraViewModel.input.accept(.dismiss)
+                }
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
close #228 

## *⛳️ Work Description*

- 단서 남기기 뷰에서 닫기 버튼으로 뷰를 닫고 카메라 뷰로 돌아오면 카메라가 재실행되지 않던 버그 수정

## *📸 Screenshot*

카메라를 포함한 영상을 찍어야 해서 실기기에서 영상 녹화했는데 8초짜리 영상이 20메가라 못 올렸습니다.

## *📢 To Reviewers*

- .presentationController?.delegate = self 로 dismiss 감지해서 작동하는 방식이였는데
  이쪽에서는 사용자가 뷰를 끌어서 내리는 건 감지하는데 코드로 dismiss 해주는 건 감지 못한다고 하네요

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
