### PR TITLE
[Fix] 앱스토어 심사 리젝 대응(수사일지 아카이브 기기대응)

### DIFF
--- a/SherlDog/Scene/MyPageTap/InvLogListViewController.swift
+++ b/SherlDog/Scene/MyPageTap/InvLogListViewController.swift
@@ -125,10 +125,10 @@ extension InvLogListViewController {
     private func configureCollectionViewLayout() -> UICollectionViewCompositionalLayout {
         return UICollectionViewCompositionalLayout { index, environment in
             let item = NSCollectionLayoutItem(layoutSize: .init(widthDimension: .fractionalWidth(1),
-                                                                heightDimension: .fractionalHeight(1/4)))
+                                                                heightDimension: .fractionalHeight(1)))
             
             let group = NSCollectionLayoutGroup.vertical(layoutSize: .init(widthDimension: .fractionalWidth(1),
-                                                                           heightDimension: .fractionalHeight(1)),
+                                                                           heightDimension: .estimated(154)),
                                                          subitems: [item])
             
             let section = NSCollectionLayoutSection(group: group)


### PR DESCRIPTION
close #242 

## *⛳️ Work Description*

- 앱스토어 심사 리젝 대응
- 수사일지 아카이브 뷰의 UI가 특정 기기에서 정상적으로 표시되지 않던 문제 수정

## *📸 Screenshot*

| before | After | 
| -- | -- |
| <img src="https://github.com/user-attachments/assets/f7db47d8-0968-478e-a71e-ea1821f080ce"  width="300"/> | <img src="https://github.com/user-attachments/assets/cdd11527-8936-4e82-9d97-9993e1318d68"  width="300"/> iPad 11inch|
| <img src=""  width="300"/> | <img src="https://github.com/user-attachments/assets/559af5cf-1767-4269-9628-937c70d8c3a1"  width="300"/> iPhone SE 3|

## *📢 To Reviewers*

- groupSize, itemSize가 항상 헷갈리네요

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
