### PR TITLE
[Fix] 프로필 등록 아이폰 SE 기기대응 및 산책일지 아카이브 데이터 최신순 정렬 안되는 이슈 해결

### DIFF
--- a/SherlDog/Scene/MyPageTap/InvLogListCell.swift
+++ b/SherlDog/Scene/MyPageTap/InvLogListCell.swift
@@ -58,14 +58,9 @@ extension InvLogListCell {
             .disposed(by: disposeBag)
     }
     
-    func settingCell(data: WalkResultToList, caseNumber: String) {
-        var caseNumber = (Int(caseNumber) ?? 0) + 1
-        
-        // 앞에 0을 넣어 세 자리 수를 만들던 코드 변경
-        let formattedCaseNumber = String(format: "%03d", caseNumber)
-
+    func settingCell(data: WalkResultToList) {
         self.dateLabel.text = data.date
-        self.caseNumberLabel.text = "CASE # \(formattedCaseNumber)"
+        self.caseNumberLabel.text = "CASE # \(data.caseNumber)"
         self.dataLabel.text = "\(data.distance)  ·  \(data.duration)  ·  \(data.steps)"
     }
     

--- a/SherlDog/Scene/MyPageTap/InvLogListViewController.swift
+++ b/SherlDog/Scene/MyPageTap/InvLogListViewController.swift
@@ -25,8 +25,8 @@ class InvLogListViewController: UIViewController {
             let totalCount = dataSource.sectionModels.first?.items.count ?? 0
             let reversedIndex = totalCount - indexPath.row
             
-            cell.settingCell(data: items, caseNumber: String(reversedIndex))
-            
+            cell.settingCell(data: items)
+
             return cell
         })
     

--- a/SherlDog/Scene/MyPageTap/InvLogListViewModel.swift
+++ b/SherlDog/Scene/MyPageTap/InvLogListViewModel.swift
@@ -81,9 +81,12 @@ extension InvLogListViewModel {
             let sortedResult = result.sorted {
                 $0.createdAt.dateValue() > $1.createdAt.dateValue()
             }
-            
-            self.originalData = result
-            self.data = result.map { WalkResultToList(from: $0) }
+
+            self.originalData = sortedResult
+            self.data = sortedResult.enumerated().map { index, result in
+                let caseNumber = sortedResult.count - index  // 최신이 큰 번호
+                return WalkResultToList(from: result, caseNumber: caseNumber)
+            }
         })
         .disposed(by: disposeBag)
     }

--- a/SherlDog/Scene/MyPageTap/MyPageViewController.swift
+++ b/SherlDog/Scene/MyPageTap/MyPageViewController.swift
@@ -106,6 +106,8 @@ class MyPageViewController : UIViewController {
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.decelerationRate = UIScrollView.DecelerationRate.fast
         collectionView.backgroundColor = .keycolorInverse
+        collectionView.isUserInteractionEnabled = true
+        collectionView.allowsSelection = true
         
         pageControl.numberOfPages = 0
         pageControl.currentPage = 0
@@ -278,7 +280,10 @@ class MyPageViewController : UIViewController {
             .subscribe(onNext: { [weak self] item in
                 switch item {
                 case .profile(let profile):
-                    _ = self?.presentRegistrationViewController(with: profile)
+                    self?.presentRegistrationViewController(with: profile)
+                        .subscribe(onNext: { _ in
+                        })
+                        .disposed(by: self?.disposeBag ?? DisposeBag())
                 case .addProfile:
                     self?.presentRegistrationView()
                 }

--- a/SherlDog/Scene/MyPageTap/WalkResultToList.swift
+++ b/SherlDog/Scene/MyPageTap/WalkResultToList.swift
@@ -12,10 +12,11 @@ struct WalkResultToList {
     let distance: String
     let duration: String
     let steps: String
+    let caseNumber: String
 }
 
 extension WalkResultToList {
-    init(from result: WalkResult) {
+    init(from result: WalkResult, caseNumber: Int) {
         let formatter = DateFormatter()
         
         // MARK: result.date transform -
@@ -45,5 +46,6 @@ extension WalkResultToList {
         self.distance = String(format: "%.1fkm", result.distance / 1000.0)
         self.duration = duration
         self.steps = "\(result.steps)보"
+        self.caseNumber = String(format: "%03d", caseNumber)
     }
 }

--- a/SherlDog/Scene/User/PetProfile/BirthSelectViewController.swift
+++ b/SherlDog/Scene/User/PetProfile/BirthSelectViewController.swift
@@ -60,12 +60,12 @@ class BirthSelectViewController: UIViewController {
     
     private func configureUI() {
         birthSelectLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(34 + 16)
+            $0.top.equalToSuperview().inset(28)
             $0.leading.equalToSuperview().inset(16)
         }
         
         underLine.snp.makeConstraints {
-            $0.top.equalTo(birthSelectLabel.snp.bottom).offset(20)
+            $0.top.equalTo(birthSelectLabel.snp.bottom).offset(18)
             $0.leading.trailing.equalToSuperview().inset(16)
             $0.height.equalTo(1)
         }
@@ -76,7 +76,7 @@ class BirthSelectViewController: UIViewController {
         }
         
         completeButton.snp.makeConstraints {
-            $0.top.equalTo(datePicker.snp.bottom).offset(12 + 16)
+            $0.top.equalTo(datePicker.snp.bottom).offset(4)
             $0.leading.trailing.equalToSuperview().inset(16)
         }
     }

--- a/SherlDog/Scene/User/PetProfile/RegistrationViewController.swift
+++ b/SherlDog/Scene/User/PetProfile/RegistrationViewController.swift
@@ -315,12 +315,23 @@ class RegistrationViewController: UIViewController {
                     .disposed(by: birthSelectVC.disposeBag)
                 
                 if let sheet = birthSelectVC.sheetPresentationController {
-                    sheet.detents = [.medium()]
-                    sheet.selectedDetentIdentifier = .medium
+                    let screenHeight = UIScreen.main.bounds.height
+                    let isIPhoneSE = screenHeight <= 667
+                    
+                    if isIPhoneSE {
+                        sheet.detents = [.medium()]
+                        sheet.selectedDetentIdentifier = .medium
+                    } else {
+                        let customDetent = UISheetPresentationController.Detent.custom { _ in 360 }
+                        sheet.detents = [customDetent, .medium()]
+                        // 첫 번째 detent가 자동으로 선택됨
+                    }
+                    
                     sheet.prefersGrabberVisible = true
                     sheet.preferredCornerRadius = 20
                 }
                 owner.present(birthSelectVC, animated: true)
+
             })
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

-프로필 등록 아이폰 SE 기기대응 완료했습니다.
- 산책일지 아카이브 데이터 최신순 정렬 안되는 이슈 해결했습니다.
- 겸사겸사 마이페이지에서 프로필 수정 가능하게 했습니다.

## *📸 Screenshot*

| iPad11 | iPhonePro16Max | iPhone15 |
| -- | -- | -- |
| ![스크린샷 2025-07-01 19 01 33](https://github.com/user-attachments/assets/e91f8d81-954f-40f3-b174-64032e28119f) | ![스크린샷 2025-07-01 18 57 32](https://github.com/user-attachments/assets/4ddcd736-f631-4a5d-805c-d14eb1d2c180) | ![스크린샷 2025-07-01 18 49 51](https://github.com/user-attachments/assets/0d6056b3-c0df-40f5-9fee-74340eb24828) |



## *📢 To Reviewers*

- 리뷰어에게 하고 싶은 말

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
