### PR TITLE
[Fix] SE에서 단서남기기 모달시트 엑스버튼 짤림 해결

### DIFF
--- a/SherlDog.xcodeproj/project.pbxproj
+++ b/SherlDog.xcodeproj/project.pbxproj
@@ -221,6 +221,8 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = YM7ARGY64W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SherlDog/Resources/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "멍탐정 산책일지";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -260,6 +262,8 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = YM7ARGY64W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SherlDog/Resources/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "멍탐정 산책일지";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/SherlDog/Scene/HomeTap/Clue/ClueDetailViewController.swift
+++ b/SherlDog/Scene/HomeTap/Clue/ClueDetailViewController.swift
@@ -80,7 +80,7 @@ final class ClueDetailViewController: UIViewController {
         }
         
         pageControl.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(24)
+            $0.bottom.equalToSuperview().inset(isIPhoneSE() ? 8 : 24)
             $0.centerX.equalToSuperview()
         }
         
@@ -91,6 +91,11 @@ final class ClueDetailViewController: UIViewController {
     
     @objc private func backButtonTapped() {
         dismiss(animated: true)
+    }
+    
+    private func isIPhoneSE() -> Bool {
+        let screenHeight = UIScreen.main.bounds.height
+        return screenHeight <= 667 // SE 1세대(568), SE 2/3세대(667)
     }
     
     private func bindViewModel() {

--- a/SherlDog/Scene/HomeTap/Clue/ClueInputViewController.swift
+++ b/SherlDog/Scene/HomeTap/Clue/ClueInputViewController.swift
@@ -101,7 +101,7 @@ class ClueInputViewController: UIViewController {
     private func setupConstraints() {
         clueLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(16)
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(26)
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(isIPhoneSE() ? 12 : 26)
         }
         
         cancelButton.snp.makeConstraints {
@@ -110,7 +110,7 @@ class ClueInputViewController: UIViewController {
         }
         
         imageView.snp.makeConstraints {
-            $0.top.equalTo(clueLabel.snp.bottom).offset(12)
+            $0.top.equalTo(clueLabel.snp.bottom).offset(isIPhoneSE() ? 26 : 12)
             $0.leading.trailing.equalToSuperview().inset(16)
             $0.height.equalTo(imageView.snp.width).multipliedBy(1.1).priority(.low)
             $0.height.greaterThanOrEqualTo(100).priority(.low)
@@ -128,11 +128,16 @@ class ClueInputViewController: UIViewController {
         }
         
         registerButton.snp.makeConstraints {
-            $0.top.equalTo(textView.snp.bottom).offset(32)
+            $0.top.equalTo(textView.snp.bottom).offset(isIPhoneSE() ? 12 : 32)
             $0.leading.trailing.equalToSuperview().inset(16)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(16)
             $0.height.equalTo(52)
         }
+    }
+    
+    private func isIPhoneSE() -> Bool {
+        let screenHeight = UIScreen.main.bounds.height
+        return screenHeight <= 667 // SE 1세대(568), SE 2/3세대(667)
     }
     
     private func bindRegisterAction() {


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

 - SE에서 단서남기기 모달시트 엑스버튼 짤림 해결
 - 빌드네임 멍탐정 산책일지로 변경
 - 앱 카테고리 라이프스타일로 변경
 - 단서확인하기뷰 페이지컨트롤러 겹치는 거 수정

## *📸 Screenshot*

| before | After |  After |  After | 
| -- | -- | -- | -- |
|  | ![스크린샷, 2025-07-01 오후 9 00 40](https://github.com/user-attachments/assets/e9dba7b3-add2-4f68-a5ba-7a6a4675ccd5) | ![IMG_0190](https://github.com/user-attachments/assets/0673a5d9-b888-4274-8702-5a8180e29d12) | ![IMG_0189](https://github.com/user-attachments/assets/a2bc8690-e437-4f51-b4cd-718d3d79478f) |

## *📢 To Reviewers*

- 리뷰어에게 하고 싶은 말

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
