### PR TITLE
[Fix] 프로필등록 멍탐정 배경화면 색상 변경

### DIFF
--- a/SherlDog/Scene/MyPageTap/MyPageViewModel.swift
+++ b/SherlDog/Scene/MyPageTap/MyPageViewModel.swift
@@ -118,7 +118,7 @@ class MyPageViewModel {
             },
             onFailure: { [weak self] error in
                 self?.output.errorMessage.onNext("HumanProfile 로드 실패: \(error.localizedDescription)")
-                let defaultProfile = HumanProfileModel(nickname: "똥봉투 조수", image: "", introduce: "")
+                let defaultProfile = HumanProfileModel(nickname: "똥봉투조수", image: "", introduce: "")
                 self?.output.humanProfile.accept(defaultProfile)
             }
         )

--- a/SherlDog/Scene/User/HumanProfile/CreateAssistantProfileViewController.swift
+++ b/SherlDog/Scene/User/HumanProfile/CreateAssistantProfileViewController.swift
@@ -246,6 +246,18 @@ extension CreateAssistantProfileViewController {
             .bind(to: viewModel.image)
             .disposed(by: disposeBag)
         
+        // 뷰모델 이미지 변경을 profileImageView에 바인딩
+        viewModel.image
+            .asObservable()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] image in
+                if let image = image {
+                    self?.profileImageView.image = image
+                    self?.profileImageView.contentMode = .scaleAspectFill
+                }
+            })
+            .disposed(by: disposeBag)
+        
         // 로딩 상태 처리
         viewModel.isLoading
             .subscribe(onNext: { [weak self] isLoading in
@@ -289,6 +301,10 @@ extension CreateAssistantProfileViewController {
         //수정모드일 때 다음 버튼 타이틀 변경
         viewModel.nextButtonTitle
             .bind(to: nextButton.rx.title(for: .normal))
+            .disposed(by: disposeBag)
+        
+        viewModel.isSaveEnabled
+            .bind(to: nextButton.rx.isEnabled)
             .disposed(by: disposeBag)
     }
     

--- a/SherlDog/Scene/User/HumanProfile/HumanProfileViewModel.swift
+++ b/SherlDog/Scene/User/HumanProfile/HumanProfileViewModel.swift
@@ -56,6 +56,14 @@ final class HumanProfileViewModel {
         }
     }
     
+    var isSaveEnabled: Observable<Bool> {
+        return Observable
+            .combineLatest(nickname, introduce, image)
+            .map { nickname, introduce, image in
+                return !nickname.isEmpty && !introduce.isEmpty && image != nil
+            }
+    }
+    
     var nextButtonTitle: Observable<String> {
         return isEditMode.asObservable().map { isEdit in
             return isEdit ? "수정 완료" : "다음"

--- a/SherlDog/Scene/User/PetProfile/DetectiveCardCollectionViewCell.swift
+++ b/SherlDog/Scene/User/PetProfile/DetectiveCardCollectionViewCell.swift
@@ -44,7 +44,7 @@ class DetectiveCardCollectionViewCell: UICollectionViewCell {
             detectiveNumber = detectiveNumberFormatter.string(from: birthDate)
         }
         
-        self.backgroundColor = .keycolorInverse
+        self.backgroundColor = .clear
         detectiveCardView.detectiveNumber.text = detectiveNumber
         detectiveCardView.detectiveName.text = profile.name
         detectiveCardView.detectiveBreed.text = profile.breed


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

-  프로필등록 멍탐정카드 배경 흰색 테두리 삭제
- 조수 프로필 등록 실패시 기본으로 들어가는 조수명에 띄어쓰기 삭제
- 조수프로필 수정시 이미지 안 보이는 문제 해결 및 모든 정보값 있을 때 수정 완료 버튼 활성화

## *📸 Screenshot*

| After | After | 
| -- | -- |
| ![스크린샷 2025-07-02 18 24 31](https://github.com/user-attachments/assets/b6f0567e-8e36-4a6e-8433-36e2e4ae99d0) | ![스크린샷 2025-07-02 18 23 23](https://github.com/user-attachments/assets/0c8c01e7-882b-4e47-b5f7-b709556993b1) |

## *📢 To Reviewers*

- 리뷰어에게 하고 싶은 말

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
