### PR TITLE
[Fix] MyPage 버그 수정 및 코드 리펙토링

### DIFF
--- a/SherlDog/Scene/HomeTap/Main/MainViewController.swift
+++ b/SherlDog/Scene/HomeTap/Main/MainViewController.swift
@@ -137,6 +137,7 @@ class MainViewController: UIViewController {
         super.viewWillAppear(animated)
         self.navigationController?.setNavigationBarHidden(true, animated: false)
         loadSavedClues()
+        requestViewModel.fetchPetProfiles()
     }
     
     // 저장된 단서들을 Firebase에서 불러와서 마커로 표시

--- a/SherlDog/Scene/MyPageTap/MyPageViewController.swift
+++ b/SherlDog/Scene/MyPageTap/MyPageViewController.swift
@@ -11,7 +11,7 @@ import RxSwift
 import RxCocoa
 import FirebaseAuth
 
-class MyPageViewController : UIViewController {
+class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrollViewDelegate {
     private let viewModel = MyPageViewModel()
     private let disposeBag = DisposeBag()
     private let maxProfileCount = 3
@@ -113,6 +113,7 @@ class MyPageViewController : UIViewController {
         collectionView.backgroundColor = .keycolorInverse
         collectionView.isUserInteractionEnabled = true
         collectionView.allowsSelection = true
+        collectionView.delegate = self
         
         pageControl.numberOfPages = 0
         pageControl.currentPage = 0
@@ -368,6 +369,28 @@ class MyPageViewController : UIViewController {
             
             // 페이지 컨트롤도 업데이트
             pageControl.currentPage = lastIndex
+        }
+    }
+    
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView,
+                                   withVelocity velocity: CGPoint,
+                                   targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        guard let collectionView = scrollView as? UICollectionView else { return }
+        
+        let cellWidth: CGFloat = 336
+        let cellSpacing: CGFloat = 12
+        let totalCellWidth = cellWidth + cellSpacing
+        let leftInset = collectionView.contentInset.left
+        
+        let proposedOffsetX = targetContentOffset.pointee.x
+        let index = round((proposedOffsetX + leftInset) / totalCellWidth)
+        
+        let maxIdx = max(0, collectionView.numberOfItems(inSection: 0) - 1)
+        let targetIndex = Int(max(0, min(index, CGFloat(maxIdx))))
+        
+        DispatchQueue.main.async {
+            let indexPath = IndexPath(item: targetIndex, section: 0)
+            collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
         }
     }
     

--- a/SherlDog/Scene/MyPageTap/MyPageViewController.swift
+++ b/SherlDog/Scene/MyPageTap/MyPageViewController.swift
@@ -49,6 +49,11 @@ class MyPageViewController : UIViewController {
         navigationController?.setNavigationBarHidden(true, animated: animated)
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         let topLine = CALayer()


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

- [x]  6 - 조수 편집할 때, 뒤로가기 버튼이 없는 점이 어색합니다. (화면 왼쪽에서 안으로의 뒤로가기 제스처는 잘 작동)
- [ ]  10 - 멍탐정을 세마리 추가했는데, 한 마리만 이미지를 추가했고, 두마리는 기본 이미지로 설정했는데, 수사 시작하기 버튼을 눌렀을 때는 기본 이미지로 설정한 두 마리중 한마리가, 제가 추가한 다른 한 마리의 이미지로 떠요.
→정진 수정 : 킹피셔 사용하면 오류 해결할 수 있음
- [x]  10 - 마이페이지에서 멍탐정을 추가한 직후에 홈 화면으로 바로 이동하면, 수사 시작하기 버튼을 눌렀을 때 멍탐정 리스트가 제대로 잘 보이지 않는 오류가 있었어요.
→정진 수정
- [x]  6 - 명탐정 프로필 카드 좌우 스크롤 할때, 애매하게 스크롤하면 offset이 고정되지 않고 애매하게 멈춥니다.(아마도 UICollectionView의 isPagingEnabled 속성) '멍탐정이 남긴 단서' 화면에서는 이 부분이 잘 구현돼있네요.
**→ 정진 수정**

## *📸 Screenshot*

| before | After | 
| -- | -- |
|  |  |
## *📢 To Reviewers*

- 리뷰어에게 하고 싶은 말

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
