### PR TITLE
[Refactor] 펫 프로필, 조수 프로필 이미지 다운로드 로직 Kingfisher로 리팩토링

### DIFF
--- a/SherlDog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SherlDog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -256,7 +256,7 @@
     {
       "identity" : "rxcorelocation",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/RxSwiftCommunity/RxCoreLocation",
+      "location" : "https://github.com/RxSwiftCommunity/RxCoreLocation.git",
       "state" : {
         "revision" : "8b26b77851c09689c2fb6ba9cd875c203ff79797",
         "version" : "1.5.1"

--- a/SherlDog/Firebase/FirebaseImageManager.swift
+++ b/SherlDog/Firebase/FirebaseImageManager.swift
@@ -3,8 +3,6 @@ import Firebase
 import FirebaseStorage
 import FirebaseAuth
 import RxSwift
-import os.signpost
-import Kingfisher
 
 class FirebaseImageManager {
     static let shared = FirebaseImageManager()

--- a/SherlDog/Firebase/FirebaseImageManager.swift
+++ b/SherlDog/Firebase/FirebaseImageManager.swift
@@ -4,6 +4,7 @@ import FirebaseStorage
 import FirebaseAuth
 import RxSwift
 import os.signpost
+import Kingfisher
 
 class FirebaseImageManager {
     static let shared = FirebaseImageManager()
@@ -199,44 +200,20 @@ class FirebaseImageManager {
             }
         }
     }
-    
-    // MARK: - 이미지 다운로드
-    func downloadImage(userId: String, type: UploadImageFor, completion: @escaping (UIImage?) -> Void) {
-        let imagePath = "\(type)/\(userId)/\(type).jpg"
-        let imageRef = storageRef.child(imagePath)
-    
-        imageRef.getData(maxSize: 5 * 1024 * 1024) { data, error in
-            if let _ = error {
-                completion(nil)
-                return
-            }
-
-            if let data = data, let image = UIImage(data: data) {
-                completion(image)
-            } else {
-                completion(nil)
-            }
-        }
-    }
 
     // MARK: - 펫 이미지 다운로드
-    func downloadPetImage(petId: String, userId: String, completion: @escaping (UIImage?) -> Void) {
+    func downloadPetImage(petId: String, userId: String, completion: @escaping (URL?) -> Void) {
         let imagePath = "pets/\(userId)/\(petId)/profile.jpg"
         let imageRef = storageRef.child(imagePath)
         
-        let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
-        let signpostID = OSSignpostID(log: log)
-        os_signpost(.begin, log: log, name: "펫 이미지 다운로드", signpostID: signpostID)
-    
-        imageRef.getData(maxSize: 5 * 1024 * 1024) { data, error in
-            if let error = error {
+        imageRef.downloadURL { url, error in
+            guard error == nil else {
                 completion(nil)
                 return
             }
-
-            if let data = data, let image = UIImage(data: data) {
-                os_signpost(.end, log: log, name: "펫 이미지 다운로드", signpostID: signpostID)
-                completion(image)
+            
+            if let url {
+                completion(url)
             } else {
                 completion(nil)
             }

--- a/SherlDog/Reusable/Component/PictureUploadRequest/PictureUploadRequestViewCell.swift
+++ b/SherlDog/Reusable/Component/PictureUploadRequest/PictureUploadRequestViewCell.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 import SnapKit
+import Kingfisher
+import os.signpost
 
 class PictureUploadRequestViewCell: UICollectionViewCell {
     
@@ -28,32 +30,31 @@ class PictureUploadRequestViewCell: UICollectionViewCell {
     
     func settingCell(text: String, imageName: String) {
         self.label.text = text
-        if imageName.hasPrefix("http") {
-            imageView.snp.updateConstraints {
-                $0.width.height.equalTo(36)
-            }
-            // URL에서 이미지 로드
-            if let url = URL(string: imageName) {
-                DispatchQueue.global().async {
-                    if let data = try? Data(contentsOf: url),
-                       let image = UIImage(data: data) {
-                        DispatchQueue.main.async {
-                            self.imageView.image = image
-                            self.imageView.contentMode = .scaleAspectFill
-                            self.imageView.clipsToBounds = true
-                            self.imageView.layer.cornerRadius = self.imageView.frame.width / 2
-                        }
-                    }
-                }
-            }
-        } else {
-            // 기존 방식 (번들 이미지)
-            imageView.snp.updateConstraints {
-                $0.width.height.equalTo(32)
-            }
+        
+        // 이미지 이름으로 로드
+        if !imageName.hasPrefix("http") {
             self.imageView.image = UIImage(named: imageName)
-            self.imageView.tintColor = .textPrimary
-            //self.imageView.contentMode = .scaleAspectFit
+        
+            // URL에서 이미지 로드
+        } else if let url = URL(string: imageName) {
+            let processor = DownsamplingImageProcessor(size: self.imageView.bounds.size) // 크기 지정 다운 샘플링
+            
+            let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
+            let signpostID = OSSignpostID(log: log)
+            os_signpost(.begin, log: log, name: "PictureUploadRequestViewCell 펫 이미지 다운로드", signpostID: signpostID)
+            
+            self.imageView.kf.indicatorType = .activity
+            KF.url(url)
+                .placeholder(UIImage.petAvatar)
+                .setProcessor(processor)
+                .cacheOriginalImage()
+                .fade(duration: 0.25)
+                .onFailureImage(UIImage.petAvatar)
+                .onSuccess { result in
+                    os_signpost(.end, log: log, name: "PictureUploadRequestViewCell 펫 이미지 다운로드", signpostID: signpostID)
+                }
+                .onFailure { error in }
+                .set(to: self.imageView)
         }
     }
     
@@ -80,13 +81,20 @@ class PictureUploadRequestViewCell: UICollectionViewCell {
             contentView.layer.borderColor = UIColor.textPrimary.cgColor
         }
         
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        
         label.font = .title2
         label.textColor = .textPrimary
     }
     
     private func configureUI() {
+        let imageSize: CGFloat = 36
+        
+        imageView.layer.cornerRadius = imageSize / 2
+        
         imageView.snp.makeConstraints {
-            $0.width.height.equalTo(32)
+            $0.width.height.equalTo(imageSize)
             $0.leading.equalToSuperview().inset(20)
             $0.centerY.equalToSuperview()
         }

--- a/SherlDog/Reusable/Component/PictureUploadRequest/PictureUploadRequestViewCell.swift
+++ b/SherlDog/Reusable/Component/PictureUploadRequest/PictureUploadRequestViewCell.swift
@@ -8,7 +8,6 @@
 import UIKit
 import SnapKit
 import Kingfisher
-import os.signpost
 
 class PictureUploadRequestViewCell: UICollectionViewCell {
     
@@ -39,10 +38,6 @@ class PictureUploadRequestViewCell: UICollectionViewCell {
         } else if let url = URL(string: imageName) {
             let processor = DownsamplingImageProcessor(size: self.imageView.bounds.size) // 크기 지정 다운 샘플링
             
-            let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
-            let signpostID = OSSignpostID(log: log)
-            os_signpost(.begin, log: log, name: "PictureUploadRequestViewCell 펫 이미지 다운로드", signpostID: signpostID)
-            
             self.imageView.kf.indicatorType = .activity
             KF.url(url)
                 .placeholder(UIImage.petAvatar)
@@ -50,9 +45,7 @@ class PictureUploadRequestViewCell: UICollectionViewCell {
                 .cacheOriginalImage()
                 .fade(duration: 0.25)
                 .onFailureImage(UIImage.petAvatar)
-                .onSuccess { result in
-                    os_signpost(.end, log: log, name: "PictureUploadRequestViewCell 펫 이미지 다운로드", signpostID: signpostID)
-                }
+                .onSuccess { result in }
                 .onFailure { error in }
                 .set(to: self.imageView)
         }

--- a/SherlDog/Scene/HomeTab/Investigation/WalkEndModalViewController.swift
+++ b/SherlDog/Scene/HomeTab/Investigation/WalkEndModalViewController.swift
@@ -10,7 +10,6 @@ import RxSwift
 import RxCocoa
 import NMapsMap
 import Kingfisher
-import os.signpost
 
 class WalkEndModalViewController : UIViewController {
     
@@ -468,10 +467,6 @@ class WalkEndModalViewController : UIViewController {
                 if let url = URL(string: profile.image) {
                     let processor = DownsamplingImageProcessor(size: CGSize(width: 100, height: 100)) // 크기 지정 다운 샘플링
                     
-                    let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
-                    let signpostID = OSSignpostID(log: log)
-                    os_signpost(.begin, log: log, name: "WalkEndModalViewController 펫 이미지 다운로드", signpostID: signpostID)
-                    
                     imageView.kf.indicatorType = .activity
                     KF.url(url)
                         .placeholder(UIImage.petAvatar)
@@ -479,9 +474,7 @@ class WalkEndModalViewController : UIViewController {
                         .cacheOriginalImage()
                         .fade(duration: 0.25)
                         .onFailureImage(UIImage.petAvatar)
-                        .onSuccess { result in
-                            os_signpost(.end, log: log, name: "WalkEndModalViewController 펫 이미지 다운로드", signpostID: signpostID)
-                        }
+                        .onSuccess { result in }
                         .onFailure { error in }
                         .set(to: imageView)
                 }

--- a/SherlDog/Scene/HomeTab/Investigation/WalkEndModalViewController.swift
+++ b/SherlDog/Scene/HomeTab/Investigation/WalkEndModalViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 import RxSwift
 import RxCocoa
 import NMapsMap
+import Kingfisher
+import os.signpost
 
 class WalkEndModalViewController : UIViewController {
     
@@ -464,14 +466,24 @@ class WalkEndModalViewController : UIViewController {
                 
                 // URL에서 이미지 로드
                 if let url = URL(string: profile.image) {
-                    DispatchQueue.global().async {
-                        if let data = try? Data(contentsOf: url),
-                           let image = UIImage(data: data) {
-                            DispatchQueue.main.async {
-                                imageView.image = image
-                            }
+                    let processor = DownsamplingImageProcessor(size: CGSize(width: 100, height: 100)) // 크기 지정 다운 샘플링
+                    
+                    let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
+                    let signpostID = OSSignpostID(log: log)
+                    os_signpost(.begin, log: log, name: "WalkEndModalViewController 펫 이미지 다운로드", signpostID: signpostID)
+                    
+                    imageView.kf.indicatorType = .activity
+                    KF.url(url)
+                        .placeholder(UIImage.petAvatar)
+                        .setProcessor(processor)
+                        .cacheOriginalImage()
+                        .fade(duration: 0.25)
+                        .onFailureImage(UIImage.petAvatar)
+                        .onSuccess { result in
+                            os_signpost(.end, log: log, name: "WalkEndModalViewController 펫 이미지 다운로드", signpostID: signpostID)
                         }
-                    }
+                        .onFailure { error in }
+                        .set(to: imageView)
                 }
                 
                 dogImagesStack.addArrangedSubview(imageView)

--- a/SherlDog/Scene/HomeTab/Main/MainViewController.swift
+++ b/SherlDog/Scene/HomeTab/Main/MainViewController.swift
@@ -13,6 +13,8 @@ import RxSwift
 import RxCoreLocation
 import CoreLocation
 import FirebaseAuth
+import Kingfisher
+import os.signpost
 
 class MainViewController: UIViewController {
     
@@ -492,17 +494,25 @@ class MainViewController: UIViewController {
             imageView.snp.makeConstraints { $0.size.equalTo(36) }
             
             // URL인지 확인해서 이미지 로드
-            if imageName.hasPrefix("http") {
-                if let url = URL(string: imageName) {
-                    DispatchQueue.global().async {
-                        if let data = try? Data(contentsOf: url),
-                           let image = UIImage(data: data) {
-                            DispatchQueue.main.async {
-                                imageView.image = image
-                            }
-                        }
+            if imageName.hasPrefix("http"), let url = URL(string: imageName) {
+                let processor = DownsamplingImageProcessor(size: CGSize(width: 100, height: 100)) // 크기 지정 다운 샘플링
+                
+                let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
+                let signpostID = OSSignpostID(log: log)
+                os_signpost(.begin, log: log, name: "MainViewController 펫 이미지 다운로드", signpostID: signpostID)
+                
+                imageView.kf.indicatorType = .activity
+                KF.url(url)
+                    .placeholder(UIImage.petAvatar)
+                    .setProcessor(processor)
+                    .cacheOriginalImage()
+                    .fade(duration: 0.25)
+                    .onFailureImage(UIImage.petAvatar)
+                    .onSuccess { result in
+                        os_signpost(.end, log: log, name: "MainViewController 펫 이미지 다운로드", signpostID: signpostID)
                     }
-                }
+                    .onFailure { error in }
+                    .set(to: imageView)
             } else {
                 imageView.image = UIImage(named: imageName)
             }

--- a/SherlDog/Scene/HomeTab/Main/MainViewController.swift
+++ b/SherlDog/Scene/HomeTab/Main/MainViewController.swift
@@ -14,7 +14,6 @@ import RxCoreLocation
 import CoreLocation
 import FirebaseAuth
 import Kingfisher
-import os.signpost
 
 class MainViewController: UIViewController {
     
@@ -497,10 +496,6 @@ class MainViewController: UIViewController {
             if imageName.hasPrefix("http"), let url = URL(string: imageName) {
                 let processor = DownsamplingImageProcessor(size: CGSize(width: 100, height: 100)) // 크기 지정 다운 샘플링
                 
-                let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
-                let signpostID = OSSignpostID(log: log)
-                os_signpost(.begin, log: log, name: "MainViewController 펫 이미지 다운로드", signpostID: signpostID)
-                
                 imageView.kf.indicatorType = .activity
                 KF.url(url)
                     .placeholder(UIImage.petAvatar)
@@ -508,9 +503,7 @@ class MainViewController: UIViewController {
                     .cacheOriginalImage()
                     .fade(duration: 0.25)
                     .onFailureImage(UIImage.petAvatar)
-                    .onSuccess { result in
-                        os_signpost(.end, log: log, name: "MainViewController 펫 이미지 다운로드", signpostID: signpostID)
-                    }
+                    .onSuccess { result in }
                     .onFailure { error in }
                     .set(to: imageView)
             } else {

--- a/SherlDog/Scene/MyPageTab/DetectiveCardCell.swift
+++ b/SherlDog/Scene/MyPageTab/DetectiveCardCell.swift
@@ -7,7 +7,6 @@
 import UIKit
 import SnapKit
 import Kingfisher
-import os.signpost
 
 class DetectiveCardCell: UICollectionViewCell {
     static let identifier = "DetectiveCardCell"
@@ -50,10 +49,6 @@ class DetectiveCardCell: UICollectionViewCell {
             
             let processor = DownsamplingImageProcessor(size: self.cardView.detectivePhotoImageView.bounds.size) // 크기 지정 다운 샘플링
             
-            let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
-            let signpostID = OSSignpostID(log: log)
-            os_signpost(.begin, log: log, name: "DetectiveCardCell 펫 이미지 다운로드", signpostID: signpostID)
-            
             self.cardView.detectivePhotoImageView.kf.indicatorType = .activity
             KF.url(url)
                 .placeholder(UIImage.petAvatar)
@@ -61,9 +56,7 @@ class DetectiveCardCell: UICollectionViewCell {
                 .cacheOriginalImage()
                 .fade(duration: 0.25)
                 .onFailureImage(UIImage.petAvatar)
-                .onSuccess { result in
-                    os_signpost(.end, log: log, name: "DetectiveCardCell 펫 이미지 다운로드", signpostID: signpostID)
-                }
+                .onSuccess { result in }
                 .onFailure { error in }
                 .set(to: self.cardView.detectivePhotoImageView)
         }

--- a/SherlDog/Scene/MyPageTab/DetectiveCardCell.swift
+++ b/SherlDog/Scene/MyPageTab/DetectiveCardCell.swift
@@ -6,6 +6,8 @@
 //
 import UIKit
 import SnapKit
+import Kingfisher
+import os.signpost
 
 class DetectiveCardCell: UICollectionViewCell {
     static let identifier = "DetectiveCardCell"
@@ -43,10 +45,27 @@ class DetectiveCardCell: UICollectionViewCell {
         cardView.detectiveBreed.text = profile.breed
         cardView.detectiveAge.text = "\(age)세"
         cardView.detectiveIntroduce.text = "# \(profile.introduce)"
-        FirebaseImageManager.shared.downloadPetImage(petId: profile.petProfileId, userId: profile.userId) { [weak self] image in
-            DispatchQueue.main.async {
-                self?.cardView.detectivePhotoImageView.image = image
-            }
+        FirebaseImageManager.shared.downloadPetImage(petId: profile.petProfileId, userId: profile.userId) { [weak self] url in
+            guard let self else { return }
+            
+            let processor = DownsamplingImageProcessor(size: self.cardView.detectivePhotoImageView.bounds.size) // 크기 지정 다운 샘플링
+            
+            let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
+            let signpostID = OSSignpostID(log: log)
+            os_signpost(.begin, log: log, name: "DetectiveCardCell 펫 이미지 다운로드", signpostID: signpostID)
+            
+            self.cardView.detectivePhotoImageView.kf.indicatorType = .activity
+            KF.url(url)
+                .placeholder(UIImage.petAvatar)
+                .setProcessor(processor)
+                .cacheOriginalImage()
+                .fade(duration: 0.25)
+                .onFailureImage(UIImage.petAvatar)
+                .onSuccess { result in
+                    os_signpost(.end, log: log, name: "DetectiveCardCell 펫 이미지 다운로드", signpostID: signpostID)
+                }
+                .onFailure { error in }
+                .set(to: self.cardView.detectivePhotoImageView)
         }
     }
 }

--- a/SherlDog/Scene/MyPageTab/MyPageViewController.swift
+++ b/SherlDog/Scene/MyPageTab/MyPageViewController.swift
@@ -10,6 +10,8 @@ import SnapKit
 import RxSwift
 import RxCocoa
 import FirebaseAuth
+import Kingfisher
+import os.signpost
 
 class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrollViewDelegate {
     private let viewModel = MyPageViewModel()
@@ -337,13 +339,24 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
     }
     
     private func loadImage(from url: URL) {
-        DispatchQueue.global().async { [weak self] in
-            if let data = try? Data(contentsOf: url), let image = UIImage(data: data) {
-                DispatchQueue.main.async {
-                    self?.assistantImage.image = image
-                }
+        let processor = DownsamplingImageProcessor(size: self.assistantImage.bounds.size) // 크기 지정 다운 샘플링
+        
+        let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
+        let signpostID = OSSignpostID(log: log)
+        os_signpost(.begin, log: log, name: "MyPageViewController 펫 이미지 다운로드", signpostID: signpostID)
+        
+        self.assistantImage.kf.indicatorType = .activity
+        KF.url(url)
+            .placeholder(UIImage.petProfile)
+            .setProcessor(processor)
+            .cacheOriginalImage()
+            .fade(duration: 0.25)
+            .onFailureImage(UIImage.petProfile)
+            .onSuccess { result in
+                os_signpost(.end, log: log, name: "MyPageViewController 펫 이미지 다운로드", signpostID: signpostID)
             }
-        }
+            .onFailure { error in }
+            .set(to: self.assistantImage)
     }
     
     // 인덱스 닷 누르면 해당 순서의 멍카드 화면 중앙으로 이동

--- a/SherlDog/Scene/MyPageTab/MyPageViewController.swift
+++ b/SherlDog/Scene/MyPageTab/MyPageViewController.swift
@@ -11,7 +11,6 @@ import RxSwift
 import RxCocoa
 import FirebaseAuth
 import Kingfisher
-import os.signpost
 
 class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrollViewDelegate {
     private let viewModel = MyPageViewModel()
@@ -341,10 +340,6 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
     private func loadImage(from url: URL) {
         let processor = DownsamplingImageProcessor(size: self.assistantImage.bounds.size) // 크기 지정 다운 샘플링
         
-        let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
-        let signpostID = OSSignpostID(log: log)
-        os_signpost(.begin, log: log, name: "MyPageViewController 펫 이미지 다운로드", signpostID: signpostID)
-        
         self.assistantImage.kf.indicatorType = .activity
         KF.url(url)
             .placeholder(UIImage.petProfile)
@@ -352,9 +347,7 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
             .cacheOriginalImage()
             .fade(duration: 0.25)
             .onFailureImage(UIImage.petProfile)
-            .onSuccess { result in
-                os_signpost(.end, log: log, name: "MyPageViewController 펫 이미지 다운로드", signpostID: signpostID)
-            }
+            .onSuccess { result in }
             .onFailure { error in }
             .set(to: self.assistantImage)
     }

--- a/SherlDog/Scene/User/HumanProfile/CreateAssistantProfileViewController.swift
+++ b/SherlDog/Scene/User/HumanProfile/CreateAssistantProfileViewController.swift
@@ -10,7 +10,6 @@ import RxSwift
 import RxCocoa
 import SnapKit
 import Kingfisher
-import os.signpost
 
 // MARK: - AssistantProfileViewController
 class CreateAssistantProfileViewController: UIViewController {
@@ -241,10 +240,6 @@ extension CreateAssistantProfileViewController {
                     
                     let processor = DownsamplingImageProcessor(size: self.profileImageView.bounds.size) // 크기 지정 다운 샘플링
                     
-                    let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
-                    let signpostID = OSSignpostID(log: log)
-                    os_signpost(.begin, log: log, name: "CreateAssistantProfileViewController 수정 조수 이미지 다운로드", signpostID: signpostID)
-                    
                     self.profileImageView.kf.indicatorType = .activity
                     KF.url(imageUrl)
                         .placeholder(UIImage.petProfile)
@@ -252,9 +247,7 @@ extension CreateAssistantProfileViewController {
                         .cacheOriginalImage()
                         .fade(duration: 0.25)
                         .onFailureImage(UIImage.petProfile)
-                        .onSuccess { result in
-                            os_signpost(.end, log: log, name: "CreateAssistantProfileViewController 수정 조수 이미지 다운로드", signpostID: signpostID)
-                        }
+                        .onSuccess { result in }
                         .onFailure { error in }
                         .set(to: self.profileImageView) 
                 }

--- a/SherlDog/Scene/User/HumanProfile/CreateAssistantProfileViewController.swift
+++ b/SherlDog/Scene/User/HumanProfile/CreateAssistantProfileViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 import RxSwift
 import RxCocoa
 import SnapKit
+import Kingfisher
+import os.signpost
 
 // MARK: - AssistantProfileViewController
 class CreateAssistantProfileViewController: UIViewController {
@@ -74,47 +76,23 @@ extension CreateAssistantProfileViewController {
         // 글자 수 업데이트
         nickNameConstraintsLabel.text = "\(viewModel.nickname.value.count) / 12자"
         introduceConstraintsLabel.text = "\(viewModel.introduce.value.count) / 150자"
-        
-        // 이미지 설정
-        if let image = viewModel.image.value {
-            profileImageView.image = image
-        }
     
         nicknameTextField.sendActions(for: .editingChanged)
         
         if let delegate = introduceTextView.delegate {
             delegate.textViewDidChange?(introduceTextView)
         }
-        
-        loadProfileImage()
-    }
-    
-    private func loadProfileImage() {
-        guard case .edit(let profile) = viewModel.currentMode else { return }
-        
-        FirebaseImageManager.shared.downloadImage(
-            userId: viewModel.userId ?? "",
-            type: .assistant
-        ) { [weak self] image in
-            DispatchQueue.main.async {
-                if let image = image {
-                    self?.selectedImage = image
-                    self?.profileImageView.image = image
-                    self?.cameraViewModel.output.capturedImage.accept(image)
-                }
-            }
-        }
     }
     
     private func bind() {
         Observable.combineLatest(
             self.cameraViewModel.output.capturedImage,
-            self.avatarViewModel.output.selectedAvatar,
+            self.avatarViewModel.output.icon,
             self.nicknameTextField.rx.text,
             self.introduceTextView.rx.text
         )
         .subscribe(onNext: { [weak self] image, avatar, nickName, introduce in
-            if image != nil || avatar != nil,
+            if image != nil || avatar != "",
                nickName != "",
                introduce != "" {
                 if let nickName, nickName.contains(" ") {
@@ -239,7 +217,7 @@ extension CreateAssistantProfileViewController {
         // 카메라로 촬영한 이미지 바인딩
         cameraViewModel.output.capturedImage
             .compactMap { $0 }
-            .bind(to: viewModel.image)
+            .bind(to: viewModel.imageForUpload)
             .disposed(by: disposeBag)
         
         // 아바타 선택한 이미지 바인딩
@@ -250,17 +228,35 @@ extension CreateAssistantProfileViewController {
                 let imageName = self.avatarViewModel.output.icon.value
                 return UIImage(named: imageName)
             }
-            .bind(to: viewModel.image)
+            .bind(to: viewModel.imageForUpload)
             .disposed(by: disposeBag)
         
         // 뷰모델 이미지 변경을 profileImageView에 바인딩
-        viewModel.image
+        viewModel.imageString
             .asObservable()
             .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] image in
-                if let image = image {
-                    self?.profileImageView.image = image
-                    self?.profileImageView.contentMode = .scaleAspectFill
+            .subscribe(onNext: { [weak self] imageString in
+                if let self, let imageUrl = URL(string: imageString) {
+                    self.profileImageView.contentMode = .scaleAspectFill
+                    
+                    let processor = DownsamplingImageProcessor(size: self.profileImageView.bounds.size) // 크기 지정 다운 샘플링
+                    
+                    let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
+                    let signpostID = OSSignpostID(log: log)
+                    os_signpost(.begin, log: log, name: "CreateAssistantProfileViewController 수정 조수 이미지 다운로드", signpostID: signpostID)
+                    
+                    self.profileImageView.kf.indicatorType = .activity
+                    KF.url(imageUrl)
+                        .placeholder(UIImage.petProfile)
+                        .setProcessor(processor)
+                        .cacheOriginalImage()
+                        .fade(duration: 0.25)
+                        .onFailureImage(UIImage.petProfile)
+                        .onSuccess { result in
+                            os_signpost(.end, log: log, name: "CreateAssistantProfileViewController 수정 조수 이미지 다운로드", signpostID: signpostID)
+                        }
+                        .onFailure { error in }
+                        .set(to: self.profileImageView) 
                 }
             })
             .disposed(by: disposeBag)

--- a/SherlDog/Scene/User/HumanProfile/HumanProfileViewModel.swift
+++ b/SherlDog/Scene/User/HumanProfile/HumanProfileViewModel.swift
@@ -9,13 +9,13 @@ import Firebase
 import RxSwift
 import RxRelay
 import UIKit
-import os.signpost
 
 final class HumanProfileViewModel {
     
     let nickname = BehaviorRelay<String>(value: "")
     let introduce = BehaviorRelay<String>(value: "")
-    let image = BehaviorRelay<UIImage?>(value: nil)
+    let imageString = BehaviorRelay<String>(value: "")
+    let imageForUpload = BehaviorRelay<UIImage?>(value: nil)
     let saveResult = PublishSubject<Result<Void, Error>>()
     let isLoading = PublishRelay<Bool>()
 
@@ -36,7 +36,7 @@ final class HumanProfileViewModel {
         nickname.accept(profile.nickname)
         introduce.accept(profile.introduce)
         
-        loadExistingImage(from: profile.image)
+        self.imageString.accept(profile.image)
     }
     
     func setCreateMode() {
@@ -45,7 +45,7 @@ final class HumanProfileViewModel {
         
         nickname.accept("")
         introduce.accept("")
-        image.accept(nil)
+        imageString.accept("")
     }
     
     func saveProfile() {
@@ -59,7 +59,7 @@ final class HumanProfileViewModel {
     
     var isSaveEnabled: Observable<Bool> {
         return Observable
-            .combineLatest(nickname, introduce, image)
+            .combineLatest(nickname, introduce, imageForUpload)
             .map { nickname, introduce, image in
                 return !nickname.isEmpty && !introduce.isEmpty && image != nil
             }
@@ -77,24 +77,8 @@ final class HumanProfileViewModel {
         }
     }
     
-    private func loadExistingImage(from imageUrl: String) {
-        guard !imageUrl.isEmpty, let url = URL(string: imageUrl) else { return }
-        let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
-        let signpostID = OSSignpostID(log: log)
-        os_signpost(.begin, log: log, name: "조수 프로필 이미지 다운로드", signpostID: signpostID)
-        
-        URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
-            if let data = data, let loadedImage = UIImage(data: data) {
-                DispatchQueue.main.async {
-                    os_signpost(.end, log: log, name: "조수 프로필 이미지 다운로드", signpostID: signpostID)
-                    self?.image.accept(loadedImage)
-                }
-            }
-        }.resume()
-    }
-    
     func uploadAndSaveProfile() {
-        guard let image = image.value,
+        guard let image = imageForUpload.value,
               !nickname.value.isEmpty,
               !introduce.value.isEmpty,
               let userId = Auth.auth().currentUser?.uid else {
@@ -143,7 +127,7 @@ final class HumanProfileViewModel {
     
     func updateProfile() {
         guard case .edit(let originalProfile) = currentMode,
-              let image = image.value,
+              let image = imageForUpload.value,
               !nickname.value.isEmpty,
               !introduce.value.isEmpty,
               let userId = Auth.auth().currentUser?.uid else {

--- a/SherlDog/Scene/User/PetProfile/DetectiveCardCollectionViewCell.swift
+++ b/SherlDog/Scene/User/PetProfile/DetectiveCardCollectionViewCell.swift
@@ -8,6 +8,8 @@ import SnapKit
 import UIKit
 import RxSwift
 import RxCocoa
+import Kingfisher
+import os.signpost
 
 class DetectiveCardCollectionViewCell: UICollectionViewCell {
     
@@ -46,10 +48,27 @@ class DetectiveCardCollectionViewCell: UICollectionViewCell {
         detectiveCardView.detectiveBreed.text = profile.breed
         detectiveCardView.detectiveAge.text = "\(age)세"
         detectiveCardView.detectiveIntroduce.text = "# \(profile.introduce)"
-        FirebaseImageManager.shared.downloadPetImage(petId: profile.petProfileId, userId: profile.userId) { [weak self] image in
-            DispatchQueue.main.async {
-                self?.detectiveCardView.detectivePhotoImageView.image = image
-            }
+        FirebaseImageManager.shared.downloadPetImage(petId: profile.petProfileId, userId: profile.userId) { [weak self] url in
+            guard let self else { return }
+            
+            let processor = DownsamplingImageProcessor(size: self.detectiveCardView.detectivePhotoImageView.bounds.size) // 크기 지정 다운 샘플링
+            
+            let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
+            let signpostID = OSSignpostID(log: log)
+            os_signpost(.begin, log: log, name: "DetectiveCardCollectionViewCell 펫 이미지 다운로드", signpostID: signpostID)
+            
+            self.detectiveCardView.detectivePhotoImageView.kf.indicatorType = .activity
+            KF.url(url)
+                .placeholder(UIImage.petAvatar)
+                .setProcessor(processor)
+                .cacheOriginalImage()
+                .fade(duration: 0.25)
+                .onFailureImage(UIImage.petAvatar)
+                .onSuccess { result in
+                    os_signpost(.end, log: log, name: "DetectiveCardCollectionViewCell 펫 이미지 다운로드", signpostID: signpostID)
+                }
+                .onFailure { error in }
+                .set(to: self.detectiveCardView.detectivePhotoImageView)
         }
     }
 }

--- a/SherlDog/Scene/User/PetProfile/DetectiveCardCollectionViewCell.swift
+++ b/SherlDog/Scene/User/PetProfile/DetectiveCardCollectionViewCell.swift
@@ -9,7 +9,6 @@ import UIKit
 import RxSwift
 import RxCocoa
 import Kingfisher
-import os.signpost
 
 class DetectiveCardCollectionViewCell: UICollectionViewCell {
     
@@ -53,10 +52,6 @@ class DetectiveCardCollectionViewCell: UICollectionViewCell {
             
             let processor = DownsamplingImageProcessor(size: self.detectiveCardView.detectivePhotoImageView.bounds.size) // 크기 지정 다운 샘플링
             
-            let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
-            let signpostID = OSSignpostID(log: log)
-            os_signpost(.begin, log: log, name: "DetectiveCardCollectionViewCell 펫 이미지 다운로드", signpostID: signpostID)
-            
             self.detectiveCardView.detectivePhotoImageView.kf.indicatorType = .activity
             KF.url(url)
                 .placeholder(UIImage.petAvatar)
@@ -64,9 +59,7 @@ class DetectiveCardCollectionViewCell: UICollectionViewCell {
                 .cacheOriginalImage()
                 .fade(duration: 0.25)
                 .onFailureImage(UIImage.petAvatar)
-                .onSuccess { result in
-                    os_signpost(.end, log: log, name: "DetectiveCardCollectionViewCell 펫 이미지 다운로드", signpostID: signpostID)
-                }
+                .onSuccess { result in }
                 .onFailure { error in }
                 .set(to: self.detectiveCardView.detectivePhotoImageView)
         }

--- a/SherlDog/Scene/User/PetProfile/RegistrationViewController.swift
+++ b/SherlDog/Scene/User/PetProfile/RegistrationViewController.swift
@@ -12,7 +12,6 @@ import RxCocoa
 import Firebase
 import FirebaseStorage
 import Kingfisher
-import os.signpost
 
 class RegistrationViewController: UIViewController {
     
@@ -142,10 +141,6 @@ class RegistrationViewController: UIViewController {
             
             let processor = DownsamplingImageProcessor(size: self.registedProfileImage.bounds.size) // 크기 지정 다운 샘플링
             
-            let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
-            let signpostID = OSSignpostID(log: log)
-            os_signpost(.begin, log: log, name: "RegistrationViewController 펫 이미지 다운로드", signpostID: signpostID)
-            
             self.registedProfileImage.kf.indicatorType = .activity
             KF.url(url)
                 .placeholder(UIImage.petAvatar)
@@ -154,7 +149,6 @@ class RegistrationViewController: UIViewController {
                 .fade(duration: 0.25)
                 .onFailureImage(UIImage.petAvatar)
                 .onSuccess { result in
-                    os_signpost(.end, log: log, name: "RegistrationViewController 펫 이미지 다운로드", signpostID: signpostID)
                     self.selectedImage = result.image
                     self.cameraViewModel.output.capturedImage.accept(result.image)
                 }

--- a/SherlDog/Scene/User/PetProfile/RegistrationViewController.swift
+++ b/SherlDog/Scene/User/PetProfile/RegistrationViewController.swift
@@ -11,6 +11,8 @@ import RxSwift
 import RxCocoa
 import Firebase
 import FirebaseStorage
+import Kingfisher
+import os.signpost
 
 class RegistrationViewController: UIViewController {
     
@@ -135,14 +137,29 @@ class RegistrationViewController: UIViewController {
         FirebaseImageManager.shared.downloadPetImage(
             petId: profile.petProfileId,
             userId: profile.userId
-        ) { [weak self] image in
-            DispatchQueue.main.async {
-                if let image = image {
-                    self?.selectedImage = image
-                    self?.registedProfileImage.image = image
-                    self?.cameraViewModel.output.capturedImage.accept(image)
+        ) { [weak self] url in
+            guard let self else { return }
+            
+            let processor = DownsamplingImageProcessor(size: self.registedProfileImage.bounds.size) // 크기 지정 다운 샘플링
+            
+            let log = OSLog(subsystem: "com.rak.SherlDog.imageLoading", category: .pointsOfInterest)
+            let signpostID = OSSignpostID(log: log)
+            os_signpost(.begin, log: log, name: "RegistrationViewController 펫 이미지 다운로드", signpostID: signpostID)
+            
+            self.registedProfileImage.kf.indicatorType = .activity
+            KF.url(url)
+                .placeholder(UIImage.petAvatar)
+                .setProcessor(processor)
+                .cacheOriginalImage()
+                .fade(duration: 0.25)
+                .onFailureImage(UIImage.petAvatar)
+                .onSuccess { result in
+                    os_signpost(.end, log: log, name: "RegistrationViewController 펫 이미지 다운로드", signpostID: signpostID)
+                    self.selectedImage = result.image
+                    self.cameraViewModel.output.capturedImage.accept(result.image)
                 }
-            }
+                .onFailure { error in }
+                .set(to: self.registedProfileImage)
         }
     }
     


### PR DESCRIPTION
close #296 

## *⛳️ Work Description*

- 이미지 캐싱 및 중복 로직 제거를 위한 Kingfisher 도입
- FirebaseImageManager 내 downloadPetImage 메서드의 리턴 값 변경 UIImage -> URL
- 리턴 값 변경으로 인해 HumanProfileViewModel의 image 프로퍼티를
  imageString(다운로드 받을 이미지 주소의 String값),
  imageForUpload(업로드할 이미지 UIImage타입)
  2개로 분리했습니다.
- FirebaseImageManager의 사용하지 않는 메서드 삭제(downloadImage)

## *📸 Screenshot*

외관상 변한 것은 없기에 이미지 다운로드 속도 비교입니다.
기존에도 이미지 다운로드의 경우 비동기로 진행됐기 때문에 초기 다운로드 속도의 변화는 크게 없습니다.
아래 이미지는 동일 이미지 재로딩 기준 속도 비교입니다.
| before | After | 
| -- | -- |
| 단위: s | 단위: ms |
| <img width="400" alt="image-2" src="https://github.com/user-attachments/assets/50c8fcf5-b699-40e9-af1b-1a969a3b2285" /> | <img width="400" alt="image-3" src="https://github.com/user-attachments/assets/f3ffa4f0-ede4-4674-81bf-f4e0fc09be9b" /> |

## *📢 To Reviewers*

- 기존에도 이미지 다운로드의 경우 비동기로 진행됐기 때문에 초기 다운로드 속도의 변화는 크게 없습니다.
- PictureRequestUploadViewCell
  - 이미지뷰 사이즈가 기본이미지일 경우 32, 펫 프로필일 경우에 36으로 설정되어 있던데 구분 없이 36으로 통일했습니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
