### PR TITLE
[Fix] 기능 선택 모달창 선택 완료 버튼 없이 해당 기능페이지로 넘어가게 수정 

### DIFF
--- a/SherlDog/Reusable/Component/PictureUploadRequest/PictureUploadRequestViewController.swift
+++ b/SherlDog/Reusable/Component/PictureUploadRequest/PictureUploadRequestViewController.swift
@@ -30,17 +30,17 @@ class PictureUploadRequestViewController: UIViewController { // 1: 240, 2: 320, 
         self.viewModel = viewModel
         self.cameraViewModel = cameraViewModel
         self.avatarViewModel = avatarViewModel
-
+        
         super.init(nibName: nil, bundle: nil)
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         setupUI()
         configureUI()
         outputBind()
@@ -69,15 +69,30 @@ extension PictureUploadRequestViewController {
                 case .pictureRequest, .pictureRequestForAssistant, .pictureRequestForPet:
                     self.collectionView.allowsMultipleSelection = false
                     self.setButton.isEnabled = false
+                    self.setButton.isHidden = true
                     
                 case .sherlDogRequest:
                     self.collectionView.allowsMultipleSelection = true
                     self.setButton.isEnabled = false
+                    self.setButton.isHidden = false
                     
                 case .sherlDogResult:
                     self.collectionView.allowsSelection = false
                     self.setButton.isEnabled = true
+                    self.setButton.isHidden = false
                 }
+            })
+            .disposed(by: disposeBag)
+        
+        collectionView.rx.itemSelected
+            .subscribe(onNext: { [weak self] _ in
+                self?.fetchButtonEnable()
+            })
+            .disposed(by: disposeBag)
+        
+        collectionView.rx.itemDeselected
+            .subscribe(onNext: { [weak self] _ in
+                self?.fetchButtonEnable()
             })
             .disposed(by: disposeBag)
         
@@ -171,9 +186,16 @@ extension PictureUploadRequestViewController {
     
     private func inputBind() {
         self.collectionView.rx.itemSelected
-            .subscribe(onNext: { [weak self] _ in
-                guard let self else { return }
-                self.fetchButtonEnable()
+            .subscribe(onNext: { [weak self] indexPath in
+                guard let self = self else { return }
+                guard let sender = self.viewModel.output.sender.value else { return }
+                
+                switch sender {
+                case .sherlDogRequest, .sherlDogResult:
+                    break
+                default:
+                    self.viewModel.input.accept(.setButtonTapped([indexPath.row]))
+                }
             })
             .disposed(by: disposeBag)
         
@@ -251,7 +273,7 @@ extension PictureUploadRequestViewController {
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PictureUploadRequestViewCell.identifier, for: indexPath) as? PictureUploadRequestViewCell else { return UICollectionViewCell() }
                 
                 cell.settingCell(text: section.title, imageName: section.image)
-
+                
                 return cell
             }, configureSupplementaryView: { dataSource, collectionView, title, indexPath in
                 guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader,
@@ -259,7 +281,7 @@ extension PictureUploadRequestViewController {
                                                                                    for: indexPath) as? PictureUploadRequestViewHeader else { return UICollectionReusableView() }
                 let title = dataSource.sectionModels[indexPath.section].model
                 header.setTitle(title: title)
-
+                
                 return header
             }
         )

--- a/SherlDog/Scene/User/HumanProfile/View/ViewControll/CreateAssistantProfileViewController.swift
+++ b/SherlDog/Scene/User/HumanProfile/View/ViewControll/CreateAssistantProfileViewController.swift
@@ -187,7 +187,7 @@ extension CreateAssistantProfileViewController {
                 requestView.modalPresentationStyle = .pageSheet
                 
                 if let sheet = requestView.sheetPresentationController {
-                    sheet.detents = [.custom { _ in 400 }]
+                    sheet.detents = [.custom { _ in 340 }]
                     sheet.selectedDetentIdentifier = .medium
                     sheet.prefersGrabberVisible = true
                     sheet.preferredCornerRadius = 20

--- a/SherlDog/Scene/User/PetProfile/View/ViewControll/RegistrationViewController.swift
+++ b/SherlDog/Scene/User/PetProfile/View/ViewControll/RegistrationViewController.swift
@@ -262,7 +262,7 @@ class RegistrationViewController: UIViewController {
                 requestView.modalPresentationStyle = .pageSheet
                 
                 if let sheet = requestView.sheetPresentationController {
-                    sheet.detents = [.custom { _ in 400 }]
+                    sheet.detents = [.custom { _ in 340 }]
                     sheet.selectedDetentIdentifier = .medium
                     sheet.prefersGrabberVisible = true
                     sheet.preferredCornerRadius = 20


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

- 기능 선택 모달창 선택 완료 버튼 없이 해당 기능페이지로 넘어가게 수정함. (복수선택 모달은 제외)

## *📸 Screenshot*

| 기능선택 모달 | 복수선택 모달 | 
| -- | -- |
| ![Simulator Screen Recording - iPhone 16 Pro - 2025-08-18 at 20 20 01](https://github.com/user-attachments/assets/7386669c-b98f-4338-9635-2bf91d96c2b2) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-08-18 at 20 20 21](https://github.com/user-attachments/assets/dd199d52-eaea-4c03-acb4-0bcc98fdc0df) |

## *📢 To Reviewers*

- 리뷰어에게 하고 싶은 말

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
