### PR TITLE
[Fix] 마이페이지에서 강아지 프로필 카드 삭제할 때 정말 삭제할 건지 묻는 알럿 띄우기

### DIFF
--- a/SherlDog/Extension+/Font+.swift
+++ b/SherlDog/Extension+/Font+.swift
@@ -110,7 +110,7 @@ extension UIFont {
     }
     
     static var recordTitle: UIFont {
-        return UIFont(name: "ChosunCentennial", size: 20) ?? UIFont.systemFont(ofSize: 20, weight: .regular)
+        return UIFont(name: "ChosunCentennial", size: 18) ?? UIFont.systemFont(ofSize: 20, weight: .regular)
     }
     
     static var recordTitleIsSE: UIFont {

--- a/SherlDog/Scene/User/HumanProfile/View/ViewControll/CreateAssistantProfileViewController.swift
+++ b/SherlDog/Scene/User/HumanProfile/View/ViewControll/CreateAssistantProfileViewController.swift
@@ -47,8 +47,8 @@ class CreateAssistantProfileViewController: UIViewController {
         configureUI()
         
         if viewModel.isEditMode.value {
-               setInitialUIValues()
-           }
+            setInitialUIValues()
+        }
         
         bind()
         bindViewModel()
@@ -62,21 +62,21 @@ extension CreateAssistantProfileViewController {
         viewModel.setEditMode(with: profile)
         
         DispatchQueue.main.async { [weak self] in
-              if self?.isViewLoaded == true {
-                  self?.setInitialUIValues()
-              }
-          }
+            if self?.isViewLoaded == true {
+                self?.setInitialUIValues()
+            }
+        }
     }
     
     private func setInitialUIValues() {
         // 텍스트 설정
         nicknameTextField.text = viewModel.nickname.value
         introduceTextView.text = viewModel.introduce.value
-   
+        
         // 글자 수 업데이트
         nickNameConstraintsLabel.text = "\(viewModel.nickname.value.count) / 12자"
         introduceConstraintsLabel.text = "\(viewModel.introduce.value.count) / 150자"
-    
+        
         nicknameTextField.sendActions(for: .editingChanged)
         
         if let delegate = introduceTextView.delegate {
@@ -111,7 +111,25 @@ extension CreateAssistantProfileViewController {
         
         navigationBackButton.rx.tap
             .subscribe(onNext: { [weak self] in
-                self?.navigationController?.popViewController(animated: true)
+                guard let self = self else { return }
+                
+                let alert = CustomAlertViewController(
+                    message: "작성을 종료하시겠습니까?",
+                    subMessage: "작성한 정보는 저장되지 않습니다.",
+                    buttons: [
+                        CustomAlertViewController.AlertButton(
+                            title: "취소",
+                            action: nil
+                        ),
+                        CustomAlertViewController.AlertButton(
+                            title: "확인",
+                            action: { [weak self] in
+                                self?.navigationController?.popViewController(animated: true)
+                            }
+                        )
+                    ]
+                )
+                self.present(alert, animated: true)
             })
             .disposed(by: disposeBag)
         
@@ -250,7 +268,7 @@ extension CreateAssistantProfileViewController {
                         .onFailureImage(UIImage.petProfile)
                         .onSuccess { result in }
                         .onFailure { error in }
-                        .set(to: self.profileImageView) 
+                        .set(to: self.profileImageView)
                 }
             })
             .disposed(by: disposeBag)

--- a/SherlDog/Scene/User/PetProfile/View/DetectiveCardView.swift
+++ b/SherlDog/Scene/User/PetProfile/View/DetectiveCardView.swift
@@ -39,7 +39,7 @@ class DetectiveCardView: UIView {
         button.clipsToBounds = true
         return button
     }()
-        
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
@@ -51,13 +51,13 @@ class DetectiveCardView: UIView {
     }
     
     private func setupUI() {
-
+        
         detectiveHeaderBackgroundView.addSubviews([detectiveCardLabel,
                                                    detectiveNumberLabel,
                                                    detectiveNumber])
         
         detectiveIntroduceBackgroundView.addSubview(detectiveIntroduce)
-
+        
         self.addSubviews([
             detectiveHeaderBackgroundView,
             detectivePhotoImageView,
@@ -73,7 +73,7 @@ class DetectiveCardView: UIView {
         
         self.addSubview(menuButton)
         setupMenu()
-            
+        
         self.layer.cornerRadius = 16
         self.layer.masksToBounds = true
         self.layer.borderWidth = 1
@@ -110,18 +110,18 @@ class DetectiveCardView: UIView {
         detectiveBreedLabel.verticalAlignment = .top
         detectiveBreedLabel.font = UIFont.alert1
         detectiveBreedLabel.textColor = .textSecondary
-
+        
         detectiveBreed.font = UIFont.body4
         detectiveBreed.textColor = .textPrimary
-
+        
         detectiveAgeLabel.text = "나이"
         detectiveAgeLabel.verticalAlignment = .top
         detectiveAgeLabel.font = UIFont.alert1
         detectiveAgeLabel.textColor = .textSecondary
-
+        
         detectiveAge.font = UIFont.body4
         detectiveAge.textColor = .textPrimary
-
+        
         detectiveIntroduceLabel.text = "성격 및 특성"
         detectiveIntroduceLabel.verticalAlignment = .top
         detectiveIntroduceLabel.font = UIFont.alert1
@@ -130,7 +130,7 @@ class DetectiveCardView: UIView {
         detectiveIntroduceBackgroundView.layer.cornerRadius = 24 / 2
         detectiveIntroduceBackgroundView.layer.masksToBounds = true
         detectiveIntroduceBackgroundView.backgroundColor = .gray50
-
+        
         detectiveIntroduce.font = UIFont.title5
         detectiveIntroduce.textColor = .textSecondary
     }
@@ -143,9 +143,27 @@ class DetectiveCardView: UIView {
         }
         
         let deleteAction = UIAction(title: "삭제하기", image: UIImage(systemName: "trash"), attributes: .destructive) { [weak self] _ in
-            self?.onDeleteTapped?()
+            guard let self = self else { return }
+            
+            // 삭제 확인 커스텀 알럿 생성
+            let alert = CustomAlertViewController(
+                message: "삭제된 프로필은 되돌릴 수 없습니다.",
+                subMessage: "정말 삭제하시겠습니까?",
+                buttons: [
+                    CustomAlertViewController.AlertButton(
+                        title: "취소",
+                        action: nil
+                    ),
+                    CustomAlertViewController.AlertButton(
+                        title: "삭제",
+                        action: { [weak self] in
+                            self?.onDeleteTapped?()
+                        }
+                    )
+                ]
+            )
+            self.parentViewController?.present(alert, animated: true)
         }
-        
         menuButton.menu = UIMenu(children: [editAction, deleteAction])
         menuButton.showsMenuAsPrimaryAction = true
     }
@@ -247,5 +265,16 @@ class DetectiveCardView: UIView {
             $0.bottom.trailing.equalToSuperview().inset(12)
             $0.width.height.equalTo(32)
         }
+    }
+}
+
+extension UIView {
+    var parentViewController: UIViewController? {
+        var responder: UIResponder? = self
+        while let next = responder?.next {
+            if let vc = next as? UIViewController { return vc }
+            responder = next
+        }
+        return nil
     }
 }

--- a/SherlDog/Scene/User/PetProfile/View/DetectiveCardView.swift
+++ b/SherlDog/Scene/User/PetProfile/View/DetectiveCardView.swift
@@ -147,8 +147,8 @@ class DetectiveCardView: UIView {
             
             // 삭제 확인 커스텀 알럿 생성
             let alert = CustomAlertViewController(
-                message: "삭제된 프로필은 되돌릴 수 없습니다.",
-                subMessage: "정말 삭제하시겠습니까?",
+                message: "정말 삭제하시겠습니까?",
+                subMessage: "삭제된 프로필은 되돌릴 수 없습니다.",
                 buttons: [
                     CustomAlertViewController.AlertButton(
                         title: "취소",


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

- 마이페이지에서 강아지 프로필 카드 삭제할 때 정말 삭제할 건지 묻는 알럿 띄우기
- 조수 프로필 수정View에서도 그냥 뒤로가기 가능해서 지금 나가면 저장되지 않는다는 알럿 띄웠습니다!
- 수사 종료 모달 최상단에 뜨는 산책날짜가 자꾸 짤려서 아예 폰트 크기를 수정했습니다 겸사겸사...

## *📸 Screenshot*

| 조수프로필View | 강아지 프로필 삭제 | 
| -- | -- |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2025-08-18 at 23 10 23" src="https://github.com/user-attachments/assets/207cf260-450c-44f5-abf9-be937378fead" />
 | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2025-08-18 at 23 10 15" src="https://github.com/user-attachments/assets/ffc69c70-e8aa-447d-9d43-9370e86d4d27" /> |
## *📢 To Reviewers*

- 리뷰어에게 하고 싶은 말

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
