### PR TITLE
[Fix] 기본 조수 선택시 도둑 이미지가 기본으로 설정된채로 시작하기

### DIFF
--- a/SherlDog/Scene/User/HumanProfile/View/ViewControll/SelectAvatarViewController.swift
+++ b/SherlDog/Scene/User/HumanProfile/View/ViewControll/SelectAvatarViewController.swift
@@ -79,15 +79,17 @@ extension SelectAvatarViewController {
             .disposed(by: disposeBag)
         
         self.viewModel.output.selectedAvatar
-            .asSignal()
-            .emit(onNext: { [weak self] data in
-                guard let self else { return }
-                
-                self.avatarImageView.image = UIImage(named: data.avatar)
-                self.detailTitleLabel.text = data.title
-                self.detailLabel.text = data.content
-            })
-            .disposed(by: disposeBag)
+            .compactMap { $0 }
+                .asSignal(onErrorSignalWith: .empty())
+                .emit(onNext: { [weak self] data in
+                    guard let self = self else { return }
+                    
+                    self.avatarImageView.image = UIImage(named: data.avatar)
+                    self.detailTitleLabel.text = data.title
+                    self.detailLabel.text = data.content
+                    self.choiceButton.isEnabled = true
+                })
+                .disposed(by: disposeBag)
         
         self.viewModel.output.moveToBack
             .asSignal()

--- a/SherlDog/Scene/User/HumanProfile/ViewModel/SelectAvatarViewModel.swift
+++ b/SherlDog/Scene/User/HumanProfile/ViewModel/SelectAvatarViewModel.swift
@@ -21,7 +21,7 @@ class SelectAvatarViewModel {
     struct Output {
         let cellData = BehaviorRelay(value: [SelectAvatarDataSource]())
         let moveToBack = PublishRelay<Void>()
-        let selectedAvatar = PublishRelay<AvatarModel>()
+        let selectedAvatar = BehaviorRelay<AvatarModel?>(value: nil)
         let icon = BehaviorRelay(value: "")
         let completeSelect = PublishRelay<Void>()
     }
@@ -37,6 +37,13 @@ class SelectAvatarViewModel {
     init() {
         transform()
         fetchCellData()
+        
+        if let firstAvatar = data.first {
+            output.selectedAvatar.accept(firstAvatar)
+            let icon = firstAvatar.icon
+            let selectedIcon = "selected" + icon.prefix(1).capitalized + icon.dropFirst()
+            output.icon.accept(selectedIcon)
+        }
     }
     
     private func transform() {


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

- 조수 아바타 기본 캐릭터 선택시 첫 번째 조수 프로필 미리 선택되게 하기

## *📸 Screenshot*

| After | 
| -- |
| ![Simulator Screen Recording - iPhone 15 - 2025-08-18 at 23 30 35](https://github.com/user-attachments/assets/0882ec48-5f99-4726-ba0d-0265ae34a3cd) |

## *📢 To Reviewers*

- 늦어서 죄송합니당..!!

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
