### PR TITLE
[Fix] 조수 프로필 뷰, 아바타 선택 뷰, 카메라 리퀘스트 뷰 버그 픽스

### DIFF
--- a/SherlDog/Reusable/Component/PictureUploadRequest/PictureUploadRequestViewController.swift
+++ b/SherlDog/Reusable/Component/PictureUploadRequest/PictureUploadRequestViewController.swift
@@ -195,6 +195,7 @@ extension PictureUploadRequestViewController {
                     break
                 default:
                     self.viewModel.input.accept(.setButtonTapped([indexPath.row]))
+                    self.collectionView.deselectItem(at: indexPath, animated: true)
                 }
             })
             .disposed(by: disposeBag)

--- a/SherlDog/Scene/User/HumanProfile/View/ViewControll/CreateAssistantProfileViewController.swift
+++ b/SherlDog/Scene/User/HumanProfile/View/ViewControll/CreateAssistantProfileViewController.swift
@@ -82,17 +82,19 @@ extension CreateAssistantProfileViewController {
         if let delegate = introduceTextView.delegate {
             delegate.textViewDidChange?(introduceTextView)
         }
+        
+        self.nextButton.isEnabled = true
     }
     
     private func bind() {
         Observable.combineLatest(
-            self.cameraViewModel.output.capturedImage,
-            self.avatarViewModel.output.icon,
+            self.viewModel.imageForUpload,
+            self.viewModel.imageString,
             self.nicknameTextField.rx.text,
             self.introduceTextView.rx.text
         )
-        .subscribe(onNext: { [weak self] image, avatar, nickName, introduce in
-            if image != nil || avatar != "",
+        .subscribe(onNext: { [weak self] image, imageString, nickName, introduce in
+            if image != nil || imageString != "",
                nickName != "",
                introduce != "" {
                 if let nickName, nickName.contains(" ") {
@@ -309,7 +311,7 @@ extension CreateAssistantProfileViewController {
         // 다음 버튼
         nextButton.rx.tap
             .subscribe(onNext: { [weak self] in
-                self?.viewModel.uploadAndSaveProfile()
+                self?.viewModel.saveProfile()
             })
             .disposed(by: disposeBag)
         

--- a/SherlDog/Scene/User/HumanProfile/View/ViewControll/SelectAvatarViewController.swift
+++ b/SherlDog/Scene/User/HumanProfile/View/ViewControll/SelectAvatarViewController.swift
@@ -57,6 +57,7 @@ class SelectAvatarViewController: UIViewController {
         super.viewWillAppear(animated)
         
         self.navigationController?.navigationBar.isHidden = true
+        collectionViewDefaultSelect()
     }
 }
 
@@ -123,6 +124,14 @@ extension SelectAvatarViewController {
             .map { .completeSelect }
             .bind(to: viewModel.input)
             .disposed(by: disposeBag)
+    }
+    
+    private func collectionViewDefaultSelect() {
+        if self.viewModel.output.cellData.value.count > 0 {
+            // collectionView 초기 선택
+            self.viewModel.input.accept(.avatarSelect(0))
+            self.collectionView.selectItem(at: IndexPath(row: 0, section: 0), animated: true, scrollPosition: [])
+        }
     }
     
     private func setupUI() {

--- a/SherlDog/Scene/User/HumanProfile/ViewModel/HumanProfileViewModel.swift
+++ b/SherlDog/Scene/User/HumanProfile/ViewModel/HumanProfileViewModel.swift
@@ -12,6 +12,11 @@ import UIKit
 
 final class HumanProfileViewModel {
     
+    enum Mode {
+        case create
+        case edit(HumanProfileModel)
+    }
+    
     let nickname = BehaviorRelay<String>(value: "")
     let introduce = BehaviorRelay<String>(value: "")
     let imageString = BehaviorRelay<String>(value: "")
@@ -23,11 +28,6 @@ final class HumanProfileViewModel {
     let isEditMode = BehaviorRelay<Bool>(value: false)
     let userId = Auth.auth().currentUser?.uid
     private let disposeBag = DisposeBag()
-    
-    enum Mode {
-        case create
-        case edit(HumanProfileModel)
-    }
     
     func setEditMode(with profile: HumanProfileModel) {
         currentMode = .edit(profile)
@@ -126,8 +126,7 @@ final class HumanProfileViewModel {
     }
     
     func updateProfile() {
-        guard case .edit(let originalProfile) = currentMode,
-              let image = imageForUpload.value,
+        guard case .edit(_) = currentMode,
               !nickname.value.isEmpty,
               !introduce.value.isEmpty,
               let userId = Auth.auth().currentUser?.uid else {
@@ -137,42 +136,69 @@ final class HumanProfileViewModel {
         
         isLoading.accept(true)
         
-        FirebaseImageManager.shared.uploadAssistantImage(image) { [weak self] result in
-            switch result {
-            case .success(let imageURL):
-                let updatedProfile = HumanProfileModel(
-                    nickname: self?.nickname.value ?? "",
-                    image: imageURL,
-                    introduce: self?.introduce.value ?? ""
-                )
-                
-                FirestoreManager.shared.updateDocument(
-                    collection: "HumanProfile",
-                    documentId: userId,
-                    data: updatedProfile
-                )
-                .subscribe(
-                    onCompleted: {
-                        DispatchQueue.main.async {
-                            self?.isLoading.accept(false)
-                            self?.saveResult.onNext(.success(()))
+        if let image = imageForUpload.value {
+            FirebaseImageManager.shared.uploadAssistantImage(image) { [weak self] result in
+                switch result {
+                case .success(let imageURL):
+                    let updatedProfile = HumanProfileModel(
+                        nickname: self?.nickname.value ?? "",
+                        image: imageURL,
+                        introduce: self?.introduce.value ?? ""
+                    )
+                    
+                    FirestoreManager.shared.updateDocument(
+                        collection: "HumanProfile",
+                        documentId: userId,
+                        data: updatedProfile
+                    )
+                    .subscribe(
+                        onCompleted: {
+                            DispatchQueue.main.async {
+                                self?.isLoading.accept(false)
+                                self?.saveResult.onNext(.success(()))
+                            }
+                        },
+                        onError: { error in
+                            DispatchQueue.main.async {
+                                self?.isLoading.accept(false)
+                                self?.saveResult.onNext(.failure(error))
+                            }
                         }
-                    },
-                    onError: { error in
-                        DispatchQueue.main.async {
-                            self?.isLoading.accept(false)
-                            self?.saveResult.onNext(.failure(error))
-                        }
+                    )
+                    .disposed(by: self?.disposeBag ?? DisposeBag())
+                    
+                case .failure(let error):
+                    DispatchQueue.main.async {
+                        self?.isLoading.accept(false)
+                        self?.saveResult.onNext(.failure(error))
                     }
-                )
-                .disposed(by: self?.disposeBag ?? DisposeBag())
-                
-            case .failure(let error):
+                }
+            }
+        } else if imageString.value != "" {
+            let updatedProfile = HumanProfileModel(
+                nickname: self.nickname.value,
+                image: imageString.value,
+                introduce: self.introduce.value
+            )
+            
+            FirestoreManager.shared.updateDocument(collection: "HumanProfile",
+                                                   documentId: userId,
+                                                   data: updatedProfile)
+            .subscribe(onCompleted: { [weak self] in
+                DispatchQueue.main.async {
+                    self?.isLoading.accept(false)
+                    self?.saveResult.onNext(.success(()))
+                }
+            }, onError: { [weak self] error in
                 DispatchQueue.main.async {
                     self?.isLoading.accept(false)
                     self?.saveResult.onNext(.failure(error))
                 }
-            }
+            })
+            .disposed(by: self.disposeBag)
+        } else {
+            saveResult.onNext(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "입력값이 부족합니다."])))
+            return
         }
     }
 }

--- a/SherlDog/Scene/User/HumanProfile/ViewModel/SelectAvatarViewModel.swift
+++ b/SherlDog/Scene/User/HumanProfile/ViewModel/SelectAvatarViewModel.swift
@@ -37,13 +37,6 @@ class SelectAvatarViewModel {
     init() {
         transform()
         fetchCellData()
-        
-        if let firstAvatar = data.first {
-            output.selectedAvatar.accept(firstAvatar)
-            let icon = firstAvatar.icon
-            let selectedIcon = "selected" + icon.prefix(1).capitalized + icon.dropFirst()
-            output.icon.accept(selectedIcon)
-        }
     }
     
     private func transform() {


### PR DESCRIPTION
close #340 

## *⛳️ Work Description*

- 조수 프로필 입력 뷰를 편집모드로 들어가면 이미지를 바꿔주기 전까지 완료 버튼이 활성화되지 않는 문제 수정
- 아바타 선택 창에서 다른 아바타를 선택하고 창을 닫았다가 다시 띄우면 선택했던 아바타가 남아있는 문제 수정
- 카메라 리퀘스트 뷰에서 항목을 선택해 넘어갔다가 다시 돌아와도 해당 항목이 선택되어 있는 문제 수정

## *📸 Screenshot*

| before | After | 
| -- | -- |
| <img src="https://github.com/user-attachments/assets/dcd9b734-ee63-4d42-a509-9bde76870ac0"  width="300"/> | <img src="https://github.com/user-attachments/assets/ba0dbd8b-fd91-4a4f-bdf3-58cac646b22d"  width="300"/> |

## *📢 To Reviewers*

- 추가로 프로필 수정 시 이미지가 바뀌지 않으면 이미지 업로드 로직은 스킵하고 닉네임, 자기소개만 업데이트하도록 변경했습니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
