### PR TITLE
[Refactor] 리터럴 관리 파일 먼저 PR올리기

### DIFF
--- a/SherlDog/Resources/SDLiteral.swift
+++ b/SherlDog/Resources/SDLiteral.swift
@@ -1,0 +1,21 @@
+//
+//  SDLiteral.swift
+//  SherlDog
+//
+//  Created by JIN LEE on 8/25/25.
+//
+
+enum SDLiteral {
+    
+    enum AlertMessage {
+        static let confirm = "확인"
+        static let cancel = "취소"
+    }
+    
+    enum LoginView {
+        static let helloLabelLarge: String = "반가워요!"
+        static let helloLabelSmall: String = "멍탐정과 함께 오늘의 수사를 시작해볼까요?"
+        static let loginErrorMessageTitle: String = "로그인 실패"
+        static let loginErrorMessage: String = "다시 로그인 해주세요!"
+    }
+}

--- a/SherlDog/Scene/User/LogIn/View/LoginViewController.swift
+++ b/SherlDog/Scene/User/LogIn/View/LoginViewController.swift
@@ -48,12 +48,12 @@ class LoginViewController: UIViewController {
         logo.image = UIImage(named: "bigLogo")
         logo.contentMode = .scaleAspectFit
         
-        helloLabel.text = "반가워요!"
+        helloLabel.text = SDLiteral.LoginView.helloLabelLarge
         helloLabel.font = UIFont(name: "EF_jejudoldam", size: 24)
         helloLabel.textAlignment = .center
         helloLabel.textColor = .textPrimary
         
-        helloLabel2.text = "멍탐정과 함께 오늘의 수사를 시작해볼까요?"
+        helloLabel2.text = SDLiteral.LoginView.helloLabelSmall
         helloLabel2.font = UIFont(name: "EF_jejudoldam", size: 18)
         helloLabel2.textAlignment = .center
         helloLabel2.textColor = .textPrimary
@@ -221,11 +221,11 @@ class LoginViewController: UIViewController {
     
     private func showErrorAlert(message: String) {
         let alert = UIAlertController(
-            title: "로그인 실패",
-            message: "다시 로그인 해주세요!",
+            title: SDLiteral.LoginView.loginErrorMessageTitle,
+            message: SDLiteral.LoginView.loginErrorMessage,
             preferredStyle: .alert
         )
-        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        alert.addAction(UIAlertAction(title: SDLiteral.AlertMessage.confirm, style: .default))
         present(alert, animated: true)
     }
 }


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

- 리터럴(String)을 한 파일에서 enum형식으로 관리해 오탈자를 방지하고, 코드 유지보수를 용이하게 하는 작업입니다.

## *📸 Screenshot*

UI 작업이 아니기 때문에 스크린샷은 없습니다.

## *📢 To Reviewers*

- “ㅁㄴㅇ \(asds)” → 이런 식으로 문자열 중간에 변수명을 넣는 경우

예) label.text = "총 \(totalTime) 분"을 리터럴로 관리한다면

enum SDLiteral {
    
    enum 예시 {
        static let int = "총 %d분"
        static let string = "문자열 %@"
        static let float/double = "실수 %.2f"
    }

label.text = String(format: SDLiteral.예시.int, totalTime)

이렇게 사용하면 된다고 합니다!

## 변수명 리터럴 관리 참고사항

| 지정자 | 용도                         | 예시 코드 및 결과                      |
|--------|------------------------------|----------------------------------------|
| %d     | 정수 (Int)                   | String(format: "%d", 12) → "12"        |
| %@     | 문자열 (String 및 참조형)     | String(format: "%@", "Swift") → "Swift"|
| %f     | 실수 (Float/Double)          | String(format: "%.2f", 3.14159) → "3.14"|

%d: 정수 값만 대입할 때 사용
Int 자료형만 올 수 있음
자릿수 지정: %02d로 두 자리, 부족하면 0으로 채움
예) String(format: "%02d", 5) → "05"
여러 인수: "[%d, %d]", 위치 변경: "%2$d, %1$d"

%@: 문자열 값에 사용
String 및 NSObject 계열 참조형이 올 수 있음
여러 인수: "내 이름은 %2$@ %1$@"

%f: 실수 값(Float/Double)에 사용
소수점 이하 자릿수 지정: "%.1f" 한 자리, "%.2f" 두 자리
예) String(format: "%.2f", 3.14) → "3.14"
자릿수/정렬: "%10.2f", "%-10.2f" 등


- 에셋 명도 리터럴로 관리할 수 있는데 이건 규현님과 상의해서 정하면 좋을 것 같습니다. 저는 관리해도 좋습니다!

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
