### PR TITLE
[Refactor] FirebaseManager 업로드 로직 enum 타입으로 관리하기

### DIFF
--- a/SherlDog/Firebase/FireStoreManager.swift
+++ b/SherlDog/Firebase/FireStoreManager.swift
@@ -8,15 +8,29 @@
 import Foundation
 import FirebaseFirestore
 import RxSwift
+import FirebaseAuth
 
 enum FirestoreError: Error {
     case unknown
     case noData
 }
 
+enum FirestoreCollection: String {
+    case clues = "clues"
+    case walkResult = "WalkResult"
+    case petProfile = "PetProfile"
+    case humanProfile = "HumanProfile"
+    case invLog = "InvLog"
+}
+
 final class FirestoreManager {
     static let shared = FirestoreManager()
     let db = Firestore.firestore()
+    
+    var userId: String {
+           return Auth.auth().currentUser?.uid ?? ""
+       }
+    
     private init() {}
 }
 // MARK: - 기본 쿼리 및 CRUD 메서드
@@ -24,12 +38,12 @@ extension FirestoreManager {
     
     //단일 문서 가져오기
     func fetchDocument<T: Decodable>(
-        collection: String,
+        collection: FirestoreCollection,
         documentId: String,
         type: T.Type
     ) -> Single<T> {
         return Single.create { [weak self] single in
-            self?.db.collection(collection).document(documentId).getDocument { snapshot, error in
+            self?.db.collection(collection.rawValue).document(documentId).getDocument { snapshot, error in
                 if let error = error {
                     single(.failure(error))
                 } else if let snapshot = snapshot, let data = try? snapshot.data(as: T.self) {
@@ -44,13 +58,13 @@ extension FirestoreManager {
 
     // whereField 단일조건 쿼리
     func fetchDocuments<T: Decodable>(
-        collection: String,
+        collection: FirestoreCollection,
         whereField field: String,
         isEqualTo value: Any,
         type: T.Type
     ) -> Single<[T]> {
         return Single.create { [weak self] single in
-            self?.db.collection(collection)
+            self?.db.collection(collection.rawValue)
                 .whereField(field, isEqualTo: value)
                 .getDocuments { snapshot, error in
                     if let error = error {
@@ -68,11 +82,11 @@ extension FirestoreManager {
 
     // 컬렉션 가져오기
     func fetchCollection<T: Decodable>(
-        collection: String,
+        collection: FirestoreCollection,
         type: T.Type
     ) -> Single<[T]> {
         return Single.create { [weak self] single in
-            self?.db.collection(collection)
+            self?.db.collection(collection.rawValue)
                 .getDocuments { snapshot, error in
                     if let error = error {
                         single(.failure(error))
@@ -89,7 +103,7 @@ extension FirestoreManager {
 
     //날짜 범위 fetch for day
     func fetchDocumentsForDay<T: Decodable>(
-        collection: String,
+        collection: FirestoreCollection,
         whereField field: String,
         isEqualTo value: Any,
         orderBy: String,
@@ -103,7 +117,7 @@ extension FirestoreManager {
                 return Disposables.create()
             }
             let (start, end) = self.timestampOfDay(day: day)
-            self.db.collection(collection)
+            self.db.collection(collection.rawValue)
                 .whereField(field, isEqualTo: value)
                 .whereField(orderBy, isGreaterThanOrEqualTo: start)
                 .whereField(orderBy, isLessThan: end)
@@ -123,12 +137,12 @@ extension FirestoreManager {
     
     // 원하는 문서의 도큐멘트 아이디 가져오기
       func findDocumentId(
-          collection: String,
+          collection: FirestoreCollection,
           whereField field: String,
           isEqualTo value: Any
       ) -> Single<[String]> {
           return Single.create { [weak self] single in
-              self?.db.collection(collection)
+              self?.db.collection(collection.rawValue)
                   .whereField(field, isEqualTo: value)
                   .getDocuments { snapshot, error in
                       if let error = error {
@@ -146,7 +160,7 @@ extension FirestoreManager {
 
     //문서 생성
     func createDocument<T: Encodable>(
-        collection: String,
+        collection: FirestoreCollection,
         data: T,
         documentId: String? = nil
     ) -> Completable {
@@ -156,8 +170,8 @@ extension FirestoreManager {
                 return Disposables.create()
             }
             let docRef: DocumentReference = documentId != nil ?
-                self.db.collection(collection).document(documentId!) :
-                self.db.collection(collection).document()
+            self.db.collection(collection.rawValue).document(documentId!) :
+            self.db.collection(collection.rawValue).document()
             do {
                 try docRef.setData(from: data) { error in
                     if let error = error {
@@ -175,14 +189,14 @@ extension FirestoreManager {
 
     //문서 수정
     func updateDocument<T: Codable>(
-        collection: String,
+        collection: FirestoreCollection,
         documentId: String,
         data: T
     ) -> Completable {
         return Completable.create { completable in
             do {
                 let encodedData = try Firestore.Encoder().encode(data)
-                self.db.collection(collection)
+                self.db.collection(collection.rawValue)
                     .document(documentId)
                     .updateData(encodedData) { error in
                         if let error = error {
@@ -200,11 +214,11 @@ extension FirestoreManager {
 
     //문서 삭제
     func deleteDocument(
-        collection: String,
+        collection: FirestoreCollection,
         documentId: String
     ) -> Completable {
         return Completable.create { [weak self] completable in
-            self?.db.collection(collection).document(documentId).delete { error in
+            self?.db.collection(collection.rawValue).document(documentId).delete { error in
                 if let error = error {
                     completable(.error(error))
                 } else {
@@ -225,13 +239,11 @@ extension FirestoreManager {
     }
 }
 
-// MARK: - 특정 목적별 메서드
 extension FirestoreManager {
-
-    //오늘의 내 단서 목록 가져오기
+    
     func fetchCluesForDay(userId: String, day: Date) -> Single<[ClueModel]> {
         return fetchDocumentsForDay(
-            collection: "clues",
+            collection: .clues,
             whereField: "userID",
             isEqualTo: userId,
             orderBy: "date",
@@ -239,49 +251,43 @@ extension FirestoreManager {
             type: ClueModel.self
         )
     }
-
-    //산책 결과 가져오기
+    
     func fetchWalkResults(userId: String) -> Single<[WalkResult]> {
         return fetchDocuments(
-            collection: "WalkResult",
+            collection: .walkResult,
             whereField: "userId",
             isEqualTo: userId,
             type: WalkResult.self
         )
     }
-
-    //선택된 펫 프로필들 한 번에 가져오기
+    
     func fetchSelectedPetProfiles(petProfileIds: [String]) -> Single<[PetProfile]> {
-        // 여러개를 병렬로 fetch해서 배열로 합치기
         let singles = petProfileIds.map {
-            fetchDocument(collection: "PetProfile", documentId: $0, type: PetProfile.self)
+            fetchDocument(collection: .petProfile, documentId: $0, type: PetProfile.self)
         }
         return Single.zip(singles)
     }
-
-    //내 펫 전체 프로필 가져오기
+    
     func fetchUserPetProfiles(userId: String) -> Single<[PetProfile]> {
         return fetchDocuments(
-            collection: "PetProfile",
+            collection: .petProfile,
             whereField: "userId",
             isEqualTo: userId,
             type: PetProfile.self
         )
     }
-
-    //휴먼 프로필 가져오기
+    
     func fetchHumanProfile(userId: String) -> Single<HumanProfileModel> {
         return fetchDocument(
-            collection: "HumanProfile",
+            collection: .humanProfile,
             documentId: userId,
             type: HumanProfileModel.self
         )
     }
-
-    //단일 펫프로필 ID로 문서 가져오기 (ex. ID로 새 프로필 추가)
+    
     func fetchPetProfileById(petProfileId: String) -> Single<PetProfile> {
         return fetchDocument(
-            collection: "PetProfile",
+            collection: .petProfile,
             documentId: petProfileId,
             type: PetProfile.self
         )
@@ -289,7 +295,7 @@ extension FirestoreManager {
     
     func fetchCluesForUser(userId: String) -> Single<[ClueModel]> {
         return fetchDocuments(
-            collection: "clues",
+            collection: .clues,
             whereField: "userID",
             isEqualTo: userId,
             type: ClueModel.self

--- a/SherlDog/Scene/HomeTab/Clue/View/ClueInputViewController.swift
+++ b/SherlDog/Scene/HomeTab/Clue/View/ClueInputViewController.swift
@@ -224,7 +224,7 @@ class ClueInputViewController: UIViewController {
             date: Timestamp(date: Date())
         )
         
-        FirestoreManager.shared.createDocument(collection: "clues", data: clue)
+        FirestoreManager.shared.createDocument(collection: .clues, data: clue)
             .subscribe(
                 onCompleted: { [weak self] in
                     DispatchQueue.main.async {

--- a/SherlDog/Scene/HomeTab/Investigation/View/WalkEndModalViewController.swift
+++ b/SherlDog/Scene/HomeTab/Investigation/View/WalkEndModalViewController.swift
@@ -246,7 +246,7 @@ class WalkEndModalViewController : UIViewController {
     
     private func fetchSelectedPetProfiles(petProfileIds: [String]) {
         let profileObservables = petProfileIds.map { id in
-            FirestoreManager.shared.fetchDocument(collection: "PetProfile",
+            FirestoreManager.shared.fetchDocument(collection: .petProfile,
                                                   documentId: id,
                                                   type: PetProfile.self)
         }

--- a/SherlDog/Scene/HomeTab/Investigation/ViewModel/DataTrackingViewModel.swift
+++ b/SherlDog/Scene/HomeTab/Investigation/ViewModel/DataTrackingViewModel.swift
@@ -128,7 +128,7 @@ class DataTrackingViewModel {
         )
         
         FirestoreManager.shared.createDocument(
-            collection: "WalkResult",
+            collection: .walkResult,
             data: newWalkResult)
         .subscribe(
             onCompleted: { [weak self] in

--- a/SherlDog/Scene/HomeTab/Investigation/ViewModel/InvLogViewModel.swift
+++ b/SherlDog/Scene/HomeTab/Investigation/ViewModel/InvLogViewModel.swift
@@ -26,7 +26,6 @@ class InvLogViewModel {
         let uploadError = PublishRelay<Void>()
     }
     
-    private let collection: String = "InvLog"
     private let disposeBag = DisposeBag()
     
     let input = PublishRelay<Input>()
@@ -52,7 +51,7 @@ class InvLogViewModel {
     }
     
     private func upload(image: String, content: String) {
-        FirestoreManager.shared.createDocument(collection: self.collection,
+        FirestoreManager.shared.createDocument(collection: .invLog,
                                                data: InvLogModel(userId: "unknown", image: image, content: content)) // todo: Insert userId
         .subscribe(onCompleted: { [weak self] in
             self?.output.isLoading.accept(false)

--- a/SherlDog/Scene/MyPageTab/ViewModel/InvLogListViewModel.swift
+++ b/SherlDog/Scene/MyPageTab/ViewModel/InvLogListViewModel.swift
@@ -89,14 +89,14 @@ extension InvLogListViewModel {
     }
     
     private func deleteWalkResultData(at indexPath: IndexPath) {
-        FirestoreManager.shared.findDocumentId(collection: "WalkResult",
+        FirestoreManager.shared.findDocumentId(collection: .walkResult,
                                                whereField: "walkingPathImage",
                                                isEqualTo: self.originalData[indexPath.row].walkingPathImage)
         .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .background))
         .flatMapCompletable { documentId in
             guard let id = documentId.first else { return Completable.error(FirestoreError.noData) }
             
-            return FirestoreManager.shared.deleteDocument(collection: "WalkResult", documentId: id)
+            return FirestoreManager.shared.deleteDocument(collection: .walkResult, documentId: id)
                 .andThen(FirebaseImageManager.shared.deleteImageByURL(self.originalData[indexPath.row].walkingPathImage))
         }
         .subscribe(onCompleted: { [weak self] in

--- a/SherlDog/Scene/MyPageTab/ViewModel/MyPageViewModel.swift
+++ b/SherlDog/Scene/MyPageTab/ViewModel/MyPageViewModel.swift
@@ -142,7 +142,7 @@ class MyPageViewModel {
         let profileId = profile.petProfileId
 
         FirestoreManager.shared.deleteDocument(
-            collection: "PetProfile",
+            collection: .petProfile,
             documentId: profileId
         )
         .subscribe(onCompleted: { [weak self] in

--- a/SherlDog/Scene/User/HumanProfile/ViewModel/HumanProfileViewModel.swift
+++ b/SherlDog/Scene/User/HumanProfile/ViewModel/HumanProfileViewModel.swift
@@ -98,7 +98,7 @@ final class HumanProfileViewModel {
                 ]
                 
                 FirestoreManager.shared.createDocument(
-                    collection: "HumanProfile",
+                    collection: .humanProfile,
                     data: data,
                     documentId: userId
                 ).subscribe(
@@ -147,7 +147,7 @@ final class HumanProfileViewModel {
                     )
                     
                     FirestoreManager.shared.updateDocument(
-                        collection: "HumanProfile",
+                        collection: .humanProfile,
                         documentId: userId,
                         data: updatedProfile
                     )
@@ -181,7 +181,7 @@ final class HumanProfileViewModel {
                 introduce: self.introduce.value
             )
             
-            FirestoreManager.shared.updateDocument(collection: "HumanProfile",
+            FirestoreManager.shared.updateDocument(collection: .humanProfile,
                                                    documentId: userId,
                                                    data: updatedProfile)
             .subscribe(onCompleted: { [weak self] in

--- a/SherlDog/Scene/User/PetProfile/View/ViewControll/RegistrationViewController.swift
+++ b/SherlDog/Scene/User/PetProfile/View/ViewControll/RegistrationViewController.swift
@@ -488,7 +488,7 @@ class RegistrationViewController: UIViewController {
     /// Presents the edit view for a given pet profile ID.
     private func presentEditView(for profileId: String) {
         FirestoreManager.shared.fetchDocument(
-            collection: "PetProfile",
+            collection: .petProfile,
             documentId: profileId,
             type: PetProfile.self
         )

--- a/SherlDog/Scene/User/PetProfile/ViewModel/PetProfileViewModel.swift
+++ b/SherlDog/Scene/User/PetProfile/ViewModel/PetProfileViewModel.swift
@@ -96,7 +96,7 @@ final class PetProfileViewModel {
                 }
                 let petProfileId = profiles[index].petProfileId
                 
-                return FirestoreManager.shared.deleteDocument(collection: "PetProfile", documentId: petProfileId)
+                return FirestoreManager.shared.deleteDocument(collection: .petProfile, documentId: petProfileId)
                     .andThen(Observable.just(profiles.enumerated()
                         .filter { $0.offset != index }
                         .map { $0.element }))
@@ -118,7 +118,7 @@ final class PetProfileViewModel {
         
         input.editProfileId
             .flatMapLatest { id in
-                FirestoreManager.shared.fetchDocument(collection: "PetProfile", documentId: id, type: PetProfile.self)
+                FirestoreManager.shared.fetchDocument(collection: .petProfile, documentId: id, type: PetProfile.self)
                     .asObservable()
                     .catch { [weak self] error in
                         self?.output.errorMessage.onNext("편집 프로필 로딩 실패: \(error.localizedDescription)")

--- a/SherlDog/Scene/User/PetProfile/ViewModel/RegistrationViewModel.swift
+++ b/SherlDog/Scene/User/PetProfile/ViewModel/RegistrationViewModel.swift
@@ -162,7 +162,7 @@ class RegistrationViewModel {
         )
         
         FirestoreManager.shared.createDocument(
-            collection: "PetProfile",
+            collection: .petProfile,
             data: newProfile,
             documentId: petProfileID
         )
@@ -202,7 +202,7 @@ class RegistrationViewModel {
         )
         
         FirestoreManager.shared.updateDocument(
-            collection: "PetProfile",
+            collection: .petProfile,
             documentId: petProfileID,
             data: updatedProfile
         )


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

-FirebaseManager 업로드 로직 enum 타입으로 관리하기 입니다
일단 collection만 enum타입으로 바꿔보았습니다.

documentId, whereField, isEqualTo, orderBy, day, type 등 관리해야 할 필드들이 꽤나 있는데, 단일 문서만 가져오는 건지, 문서 전체를 가져오는 건지, 컬렉션을 통째로 가져오는 건지에 따라서 요구되는 필드가 달라지기 때문에 지금 처럼 함수로 존재하는 게 나을지, 이넘으로 관리한다면 어떤 식으로 관리할 수 있는지 아직도 고민중입니다...

더불어 계속 중복되고 있는    let userId = Auth.auth().currentUser?.uid 
이 코드도 아예 파베매니저에서 관리하려고 하는데 그러다보니 이제 이넘을 어케 처리할지 결정이 되어야 하다 보니 아직 미완성에 그쳤습니다...!!

이 부분에 대해서는 함께 논의해보면 좋을 것 같습니다. 감사합니다!

## *📸 Screenshot*

코드 리펙토링이기 때문에 UI 변경은 없습니다.

| before | After | 
| -- | -- |
|  |  |
## *📢 To Reviewers*

- 리뷰어에게 하고 싶은 말

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
