### PR TITLE
[Refactor] like, comment 로직 변경

### DIFF
--- a/SherlDog/Firebase/CommunityActionManager.swift
+++ b/SherlDog/Firebase/CommunityActionManager.swift
@@ -64,7 +64,8 @@ extension CommunityActionManager {
         }
     }
     
-    func isLiked(collection: FirestoreCollection, postCode: String, userId: String) -> Observable<Bool> {
+    // Like state observer
+    func observeIsLiked(collection: FirestoreCollection, postCode: String, userId: String) -> Observable<Bool> {
         let doc = self.db
             .collection(collection.rawValue)
             .document(postCode)
@@ -84,7 +85,25 @@ extension CommunityActionManager {
         }
     }
     
-    // create
+    // Like count observer
+    func observeLikeCount(
+        collection: FirestoreCollection,
+        postCode: String
+    ) -> Observable<Int> {
+        let doc = self.db
+            .collection(collection.rawValue)
+            .document(postCode)
+
+        return Observable.create { observable in
+            let listener = doc.addSnapshotListener { snapshot, _ in
+                let count = (snapshot?.data()?["likeCount"] as? Int) ?? 0
+                observable.onNext(count)
+            }
+            return Disposables.create { listener.remove() }
+        }
+    }
+    
+    // Create Comment
     func createComment<T: Codable>(
         collection: FirestoreCollection,
         postCode: String,
@@ -116,7 +135,7 @@ extension CommunityActionManager {
         }
     }
     
-    // delete
+    // Delete Comment
     func deleteComment(
         collection: FirestoreCollection,
         postCode: String,
@@ -144,7 +163,7 @@ extension CommunityActionManager {
         }
     }
     
-    // like list 불러오기
+    // Like list 불러오기
     func fetchLikersList(
         collection: FirestoreCollection,
         postCode: String

--- a/SherlDog/Firebase/CommunityActionManager.swift
+++ b/SherlDog/Firebase/CommunityActionManager.swift
@@ -1,0 +1,235 @@
+//
+//  CommunityActionManager.swift
+//  SherlDog
+//
+//  Created by 최규현 on 9/15/25.
+//
+
+import FirebaseAuth
+import FirebaseFirestore
+import RxSwift
+
+final class CommunityActionManager {
+    static let shared = CommunityActionManager()
+    
+    enum CommunityAction: String {
+        case like = "like"
+        case comment = "comment"
+    }
+    
+    private let db = Firestore.firestore()
+    private let myUserId = Auth.auth().currentUser?.uid ?? ""
+    
+    private init() {}
+}
+
+// MARK: - Method
+extension CommunityActionManager {
+    
+    // Like 추가, 제거
+    func toggleLikeWithCount(collection: FirestoreCollection, postCode: String) -> Completable {
+        return Completable.create { [weak self] completable in
+            guard let self else {
+                completable(.error(FirestoreError.unknown))
+                return Disposables.create()
+            }
+            
+            let postRef = self.db
+                .collection(collection.rawValue)
+                .document(postCode)
+            
+            let likeRef = postRef
+                .collection(CommunityAction.like.rawValue)
+                .document(self.myUserId)
+            
+            self.db.runTransaction({ transaction, _ -> Any? in
+                let likeSnap = try? transaction.getDocument(likeRef)
+
+                if likeSnap?.exists == true {
+                    transaction.deleteDocument(likeRef)
+                    transaction.updateData(["likeCount": FieldValue.increment(Int64(-1))], forDocument: postRef)
+                } else {
+                    transaction.setData([:], forDocument: likeRef)
+                    transaction.updateData(["likeCount": FieldValue.increment(Int64(1))], forDocument: postRef)
+                }
+                return nil
+            }) { _, error in
+                if let error {
+                    completable(.error(error))
+                } else {
+                    completable(.completed)
+                }
+            }
+            return Disposables.create()
+        }
+    }
+    
+    func isLiked(collection: FirestoreCollection, postCode: String, userId: String) -> Observable<Bool> {
+        let doc = self.db
+            .collection(collection.rawValue)
+            .document(postCode)
+            .collection(CommunityActionManager.CommunityAction.like.rawValue)
+            .document(userId)
+
+        return Observable.create { observable in
+            let listener = doc.addSnapshotListener { snapshot, _ in
+                if let snapshot {
+                    observable.onNext(snapshot.exists)
+                } else {
+                    observable.onError(FirestoreError.unknown)
+                }
+            }
+            
+            return Disposables.create { listener.remove() }
+        }
+    }
+    
+    // create
+    func createComment<T: Codable>(
+        collection: FirestoreCollection,
+        postCode: String,
+        data: T
+    ) -> Completable {
+        return Completable.create { [weak self] completable in
+            guard let self else {
+                completable(.error(FirestoreError.unknown))
+                return Disposables.create()
+            }
+            
+            do {
+                try self.db.collection(collection.rawValue)
+                    .document(postCode)
+                    .collection(CommunityAction.comment.rawValue)
+                    .document()
+                    .setData(from: data) { error in
+                        if let error {
+                            completable(.error(error))
+                        } else {
+                            completable(.completed)
+                        }
+                    }
+            } catch {
+                completable(.error(error))
+            }
+            
+            return Disposables.create()
+        }
+    }
+    
+    // delete
+    func deleteComment(
+        collection: FirestoreCollection,
+        postCode: String,
+        commentDocumentId: String
+    ) -> Completable {
+        return Completable.create { [weak self] completable in
+            guard let self else {
+                completable(.error(FirestoreError.unknown))
+                return Disposables.create()
+            }
+            
+            self.db.collection(collection.rawValue)
+                .document(postCode)
+                .collection(CommunityAction.comment.rawValue)
+                .document(commentDocumentId)
+                .delete() { error in
+                    if let error {
+                        completable(.error(error))
+                    } else {
+                        completable(.completed)
+                    }
+                }
+            
+            return Disposables.create()
+        }
+    }
+    
+    // like list 불러오기
+    func fetchLikersList(
+        collection: FirestoreCollection,
+        postCode: String
+    ) -> Single<[String]> {
+        return Single.create { [weak self] single in
+            guard let self else {
+                single(.failure(FirestoreError.unknown))
+                return Disposables.create()
+            }
+            
+            self.db
+                .collection(collection.rawValue)
+                .document(postCode)
+                .collection(CommunityAction.like.rawValue)
+                .getDocuments() { snapshot, error in
+                    if let snapshot {
+                        single(.success(snapshot.documents.map { $0.documentID }))
+                    } else if let error {
+                        single(.failure(error))
+                    } else {
+                        single(.failure(FirestoreError.noData))
+                    }
+                }
+            
+            return Disposables.create()
+        }
+    }
+
+    // 코멘트 리스트 불러오기
+    func fetchCommentsList<T: Codable>(
+        collection: FirestoreCollection,
+        postCode: String
+    ) -> Single<[T]> {
+        return Single.create { [weak self] single in
+            guard let self else {
+                single(.failure(FirestoreError.unknown))
+                return Disposables.create()
+            }
+            
+            self.db
+                .collection(collection.rawValue)
+                .document(postCode)
+                .collection(CommunityAction.comment.rawValue)
+                .getDocuments() { snapshot, error in
+                    if let snapshot {
+                        single(.success(snapshot.documents.compactMap { try? $0.data(as: T.self) }))
+                    } else if let error {
+                        single(.failure(error))
+                    } else {
+                        single(.failure(FirestoreError.noData))
+                    }
+                }
+            
+            return Disposables.create()
+        }
+    }
+    
+    // comment 수정
+    func updateComment(
+        collection: FirestoreCollection,
+        postCode: String,
+        commentDocumentId: String,
+        text: String
+    ) -> Completable {
+        return Completable.create { [weak self] completable in
+            guard let self else {
+                completable(.error(FirestoreError.unknown))
+                return Disposables.create()
+            }
+            
+            self.db.collection(collection.rawValue)
+                .document(postCode)
+                .collection(CommunityAction.comment.rawValue)
+                .document(commentDocumentId)
+                .updateData(["text": text]) { error in // FIXME: "text"를 commentModel의 내용을 담은 프로퍼티 이름으로 변경
+                    if let error {
+                        completable(.error(error))
+                    } else {
+                        completable(.completed)
+                    }
+                }
+            
+            
+            return Disposables.create()
+        }
+    }
+    
+}

--- a/SherlDog/Firebase/FireStoreManager.swift
+++ b/SherlDog/Firebase/FireStoreManager.swift
@@ -219,7 +219,7 @@ final class FirestoreManager {
     }
     
     //문서 수정
-    func updateDocument<T: Codable>(
+    func updateDocument<T: Encodable>(
         collection: FirestoreCollection,
         documentId: String?,
         data: T

--- a/SherlDog/Scene/CommunityTab/Model/CommunityModel.swift
+++ b/SherlDog/Scene/CommunityTab/Model/CommunityModel.swift
@@ -17,8 +17,8 @@ struct CommunityModel: Codable {
     let postDate: Timestamp
     let contentImage: [String]
     let content: String
-    var like: [String] = []
-    var previewComment: [String] = []
+    var likeCount: Int = 0
+    var commentCount: Int = 0
     let documentId: String
     var isExpanded: Bool = false
 }

--- a/SherlDog/Scene/CommunityTab/View/AddNewContentViewController.swift
+++ b/SherlDog/Scene/CommunityTab/View/AddNewContentViewController.swift
@@ -60,7 +60,7 @@ final class AddNewContentViewController: UIViewController {
     }
     
     // Edit mode
-    init(category: CommunityViewModel.CommunitySectionType, post: CommunityModel) {
+    init(category: CommunitySectionType, post: CommunityModel) {
         super.init(nibName: nil, bundle: nil)
         
         self.viewModel.input.accept(.editCase(category: category, post: post))

--- a/SherlDog/Scene/CommunityTab/View/CommunityViewController.swift
+++ b/SherlDog/Scene/CommunityTab/View/CommunityViewController.swift
@@ -33,7 +33,7 @@ final class CommunityViewController: UIViewController {
     private let refreshControl = UIRefreshControl()
     
     // MARK: - UIProperty
-    private lazy var segmentedControl = CommunitySegmentedControl(items: CommunityViewModel.CommunitySectionType.allCases.map { $0.name })
+    private lazy var segmentedControl = CommunitySegmentedControl(items: CommunitySectionType.allCases.map { $0.name })
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewCompositionalLayout())
     private let addButton = UIButton()
     
@@ -124,7 +124,7 @@ extension CommunityViewController {
     private func myPostMenu(post: CommunityModel) -> UIMenu {
         let fixAction = UIAction(title: String(format: SDLiteral.CommunityView.menuButtonTitle,
                                                SDLiteral.CommunityView.fix)) { [weak self] action in
-            let category: CommunityViewModel.CommunitySectionType = {
+            let category: CommunitySectionType = {
                 self?.segmentedControl.selectedSegmentIndex == 0 ? .invLogBoard : .detectiveMateBoard
             }()
             
@@ -250,6 +250,8 @@ extension CommunityViewController {
 extension CommunityViewController {
     private func setDataSource() -> RxCollectionViewSectionedReloadDataSource<CommunityViewModel.CommunitySection> {
         return RxCollectionViewSectionedReloadDataSource<CommunityViewModel.CommunitySection>(
+            
+            // MARK: - PostMediaCell
             configureCell: { dataSource, collectionView, indexPath, item in
                 // item == String (이미지 URL)
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MediaCell.identifier, for: indexPath) as? MediaCell else { return .init() }
@@ -268,7 +270,9 @@ extension CommunityViewController {
             configureSupplementaryView: { dataSource, collectionView, kind, indexPath in
                 // 섹션 모델 == CommunityModel
                 let sectionModel = dataSource.sectionModels[indexPath.section].model
+                
                 switch kind {
+                    // MARK: - PostHeader
                 case UICollectionView.elementKindSectionHeader:
                     guard let header = collectionView.dequeueReusableSupplementaryView(
                         ofKind: kind,
@@ -302,6 +306,7 @@ extension CommunityViewController {
                     
                     return header
                     
+                    // MARK: - PostFooter
                 case UICollectionView.elementKindSectionFooter:
                     guard let footer = collectionView.dequeueReusableSupplementaryView(
                         ofKind: kind,
@@ -311,17 +316,36 @@ extension CommunityViewController {
                     
                     let count = dataSource.sectionModels[indexPath.section].items.count
                     let category: FirestoreCollection = {
-                        self.segmentedControl.selectedSegmentIndex == 0 ? .invLogBoard : .detectiveMate
+                        let index = self.segmentedControl.selectedSegmentIndex
+                        
+                        return CommunitySectionType.allCases.indices.contains(index)
+                        ? CommunitySectionType.allCases[index].toFirestoreCollection
+                        : .invLogBoard
                     }()
                     
                     footer.settingCell(data: sectionModel, collection: category)
                     footer.updatePage(total: count, current: 0)
+
+                    // ViewModel for footer
+                    let viewModel = PostFooterViewModel(category: category, post: sectionModel)
+                    let output = viewModel.transform(
+                        input: .init(
+                            likeTap: footer.rx.likeButtonTap
+                                .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+                                .asSignal(onErrorSignalWith: .empty())
+                        )
+                    )
+                    output.state
+                        .drive(onNext: { [weak footer] state in
+                            footer?.updateLike(state)
+                        })
+                        .disposed(by: footer.disposeBag)
                     
                     footer.rx.likeButtonTap
                         .map { sectionModel }
                         .bind(to: self.likeButtonEvent)
                         .disposed(by: footer.disposeBag)
-                    
+
                     footer.rx.containerTap
                         .observe(on: MainScheduler.instance)
                         .subscribe(onNext: { [weak self] in
@@ -334,11 +358,11 @@ extension CommunityViewController {
                                     action: nil
                                 )]
                             )
-                            
+
                             self?.present(alert, animated: true)
                         })
                         .disposed(by: footer.disposeBag)
-                    
+
                     return footer
                     
                 default:

--- a/SherlDog/Scene/CommunityTab/View/CommunityViewController.swift
+++ b/SherlDog/Scene/CommunityTab/View/CommunityViewController.swift
@@ -310,8 +310,11 @@ extension CommunityViewController {
                     ) as? PostFooterView else { return .init() }
                     
                     let count = dataSource.sectionModels[indexPath.section].items.count
+                    let category: FirestoreCollection = {
+                        self.segmentedControl.selectedSegmentIndex == 0 ? .invLogBoard : .detectiveMate
+                    }()
                     
-                    footer.settingCell(data: sectionModel)
+                    footer.settingCell(data: sectionModel, collection: category)
                     footer.updatePage(total: count, current: 0)
                     
                     footer.rx.likeButtonTap

--- a/SherlDog/Scene/CommunityTab/View/PostCell/PostFooterView.swift
+++ b/SherlDog/Scene/CommunityTab/View/PostCell/PostFooterView.swift
@@ -1,4 +1,3 @@
-//
 //  PostFooterView.swift
 //  SherlDog
 //
@@ -46,15 +45,7 @@ final class PostFooterView: UICollectionReusableView {
     
     // MARK: - Method
     func settingCell(data: CommunityModel, collection: FirestoreCollection) {
-        let likeButtonTitle = data.likeCount > 0 ? String(data.likeCount) : ""
-        
         captionLabel.text = data.content
-        
-        self.isLiker(data, collection: collection)
-        likeButton.configuration?.attributedTitle = AttributedString(
-            likeButtonTitle,
-            attributes: AttributeContainer([.font: UIFont.body6])
-        )
         
         previewCommentButton.configuration?.attributedTitle = AttributedString(
             String(data.commentCount),
@@ -63,23 +54,22 @@ final class PostFooterView: UICollectionReusableView {
         previewCommentButton.isHidden = (data.commentCount == 0 ? true : false)
     }
     
+    // Update Page
     func updatePage(total: Int, current: Int) {
         pageControl.numberOfPages = max(total, 0)
         pageControl.currentPage = min(max(current, 0), total - 1)
         pageControl.isHidden = (total <= 1)
     }
     
-    private func isLiker(_ data: CommunityModel, collection: FirestoreCollection) {
-        guard let userId = Auth.auth().currentUser?.uid else { return }
-        
-        CommunityActionManager.shared.isLiked(collection: collection, postCode: data.documentId, userId: userId)
-            .observe(on: MainScheduler.instance)
-            .subscribe { [weak self] isLiked in
-                self?.likeButton.configuration?.image = isLiked
-                ? UIImage(systemName: "heart.fill")?.withTintColor(.keycolorPrimary2, renderingMode: .alwaysOriginal)
-                : UIImage(systemName: "heart")?.withTintColor(.gray900, renderingMode: .alwaysOriginal)
-            }
-            .disposed(by: disposeBag)
+    // Update Like
+    func updateLike(_ state: PostFooterLikeState) {
+        var likeConfig = likeButton.configuration
+        likeConfig?.image = state.likeImage
+        likeConfig?.attributedTitle = AttributedString(
+            state.likeCountText,
+            attributes: AttributeContainer([.font: UIFont.body6])
+        )
+        likeButton.configuration = likeConfig
     }
 }
 

--- a/SherlDog/Scene/CommunityTab/View/PostCell/PostFooterView.swift
+++ b/SherlDog/Scene/CommunityTab/View/PostCell/PostFooterView.swift
@@ -38,25 +38,29 @@ final class PostFooterView: UICollectionReusableView {
         disposeBag = DisposeBag()
         captionLabel.text = nil
         likeButton.setTitle(nil, for: .normal)
-        likeButton.imageView?.tintColor = .gray900
+        likeButton.setImage(nil, for: .normal)
         previewCommentButton.setTitle(nil, for: .normal)
         pageControl.currentPage = 0
         pageControl.numberOfPages = 0
     }
     
     // MARK: - Method
-    func settingCell(data: CommunityModel) {
-        let likeButtonTitle = data.like.count > 0 ? String(data.like.count) : nil
+    func settingCell(data: CommunityModel, collection: FirestoreCollection) {
+        let likeButtonTitle = data.likeCount > 0 ? String(data.likeCount) : ""
         
         captionLabel.text = data.content
         
-        likeButton.configuration?.title = likeButtonTitle
-        likeButton.configuration?.image = self.isLiker(data)
-        ? UIImage(systemName: "heart.fill")?.withTintColor(.keycolorPrimary2, renderingMode: .alwaysOriginal)
-        : UIImage(systemName: "heart")?.withTintColor(.gray900, renderingMode: .alwaysOriginal)
+        self.isLiker(data, collection: collection)
+        likeButton.configuration?.attributedTitle = AttributedString(
+            likeButtonTitle,
+            attributes: AttributeContainer([.font: UIFont.body6])
+        )
         
-        previewCommentButton.configuration?.title = String(data.previewComment.count)
-        previewCommentButton.isHidden = (data.previewComment.isEmpty ? true : false)
+        previewCommentButton.configuration?.attributedTitle = AttributedString(
+            String(data.commentCount),
+            attributes: AttributeContainer([.font: UIFont.body6])
+        )
+        previewCommentButton.isHidden = (data.commentCount == 0 ? true : false)
     }
     
     func updatePage(total: Int, current: Int) {
@@ -65,9 +69,17 @@ final class PostFooterView: UICollectionReusableView {
         pageControl.isHidden = (total <= 1)
     }
     
-    private func isLiker(_ data: CommunityModel) -> Bool {
-        guard let userId = Auth.auth().currentUser?.uid else { return false }
-        return data.like.contains(where: { $0 == userId })
+    private func isLiker(_ data: CommunityModel, collection: FirestoreCollection) {
+        guard let userId = Auth.auth().currentUser?.uid else { return }
+        
+        CommunityActionManager.shared.isLiked(collection: collection, postCode: data.documentId, userId: userId)
+            .observe(on: MainScheduler.instance)
+            .subscribe { [weak self] isLiked in
+                self?.likeButton.configuration?.image = isLiked
+                ? UIImage(systemName: "heart.fill")?.withTintColor(.keycolorPrimary2, renderingMode: .alwaysOriginal)
+                : UIImage(systemName: "heart")?.withTintColor(.gray900, renderingMode: .alwaysOriginal)
+            }
+            .disposed(by: disposeBag)
     }
 }
 
@@ -110,9 +122,11 @@ extension PostFooterView {
         likeButtonConfig.buttonSize = .mini
         likeButtonConfig.image = UIImage(systemName: "heart")?.withTintColor(.gray900, renderingMode: .alwaysOriginal)
         likeButtonConfig.baseForegroundColor = .gray900
-        likeButtonConfig.title = ""
-        likeButtonConfig.attributedTitle?.font = .body6
-        likeButtonConfig.imagePadding = 4
+        likeButtonConfig.attributedTitle = AttributedString(
+            "",
+            attributes: AttributeContainer([.font: UIFont.body6])
+        )
+        likeButtonConfig.imagePadding = 2
         likeButtonConfig.contentInsets = .zero
         
         likeButton.configuration = likeButtonConfig
@@ -122,9 +136,11 @@ extension PostFooterView {
         commentButtonConfig.buttonSize = .mini
         commentButtonConfig.image = UIImage(systemName: "bubble")?.withTintColor(.gray900, renderingMode: .alwaysOriginal)
         commentButtonConfig.baseForegroundColor = .gray900
-        commentButtonConfig.title = ""
-        commentButtonConfig.attributedTitle?.font = .body6
-        commentButtonConfig.imagePadding = 4
+        commentButtonConfig.attributedTitle = AttributedString(
+            "",
+            attributes: AttributeContainer([.font: UIFont.body6])
+        )
+        commentButtonConfig.imagePadding = 2
         commentButtonConfig.contentInsets = .zero
         
         previewCommentButton.configuration = commentButtonConfig

--- a/SherlDog/Scene/CommunityTab/ViewModel/AddNewContentViewModel.swift
+++ b/SherlDog/Scene/CommunityTab/ViewModel/AddNewContentViewModel.swift
@@ -306,24 +306,21 @@ final class AddNewContentViewModel {
             .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .background))
             .flatMapCompletable { [weak self] newURLs in
                 guard let self,
-                      let userId = Auth.auth().currentUser?.uid,
                       let collection = self.getCollection(category) else {
                     return .error(FirestoreError.unknown)
                 }
                 // 기존 URL + 신규 URL 합치기
                 let merged = self.output.existingImageURLs.value + newURLs
                 let selectedPets = self.output.selectedProfile.value
-
-                let updated = CommunityModel(
-                    userId: userId,
-                    petProfile: selectedPets,
-                    postDate: post.postDate,
-                    contentImage: merged,
-                    content: self.text.value,
-                    likeCount: post.likeCount,
-                    commentCount: post.commentCount,
-                    documentId: post.documentId
-                ) // TODO: 모델 자체를 넣는 것이 아닌 일부 프로퍼티만 변경하도록
+                
+                struct PostUpdateData: Encodable {
+                    let petProfile: [PetProfile]
+                    let contentImage: [String]
+                    let content: String
+                }
+                let updated = PostUpdateData(petProfile: selectedPets,
+                                             contentImage: merged,
+                                             content: self.text.value)
                     
                 return FirestoreManager.shared.updateDocument(collection: collection,
                                                               documentId: post.documentId,

--- a/SherlDog/Scene/CommunityTab/ViewModel/AddNewContentViewModel.swift
+++ b/SherlDog/Scene/CommunityTab/ViewModel/AddNewContentViewModel.swift
@@ -18,7 +18,7 @@ final class AddNewContentViewModel {
     
     enum Mode {
         case add
-        case edit(category: CommunityViewModel.CommunitySectionType, post: CommunityModel)
+        case edit(category: CommunitySectionType, post: CommunityModel)
     }
     
     enum Input {
@@ -28,7 +28,7 @@ final class AddNewContentViewModel {
         case addPicture
         case selectedPictures([PHPickerResult])
         case deleteButtonTap(Int)
-        case editCase(category: CommunityViewModel.CommunitySectionType, post: CommunityModel)
+        case editCase(category: CommunitySectionType, post: CommunityModel)
     }
     
     struct Output {
@@ -129,7 +129,7 @@ final class AddNewContentViewModel {
             .disposed(by: disposeBag)
     }
     
-    private func setEditMode(category: CommunityViewModel.CommunitySectionType, post: CommunityModel) {
+    private func setEditMode(category: CommunitySectionType, post: CommunityModel) {
         self.output.isLoading.accept(true)
         
         let petData = self.dataBox
@@ -301,14 +301,13 @@ final class AddNewContentViewModel {
             .disposed(by: disposeBag)
     }
     
-    private func updatePost(category: CommunityViewModel.CommunitySectionType, post: CommunityModel) {
+    private func updatePost(category: CommunitySectionType, post: CommunityModel) {
         uploadNewImages(category: category)
             .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .background))
             .flatMapCompletable { [weak self] newURLs in
-                guard let self,
-                      let collection = self.getCollection(category) else {
-                    return .error(FirestoreError.unknown)
-                }
+                guard let self else { return .error(FirestoreError.unknown) }
+                let collection = category.toFirestoreCollection
+                
                 // 기존 URL + 신규 URL 합치기
                 let merged = self.output.existingImageURLs.value + newURLs
                 let selectedPets = self.output.selectedProfile.value
@@ -360,7 +359,7 @@ final class AddNewContentViewModel {
         
     }
     
-    private func uploadNewImages(category: CommunityViewModel.CommunitySectionType) -> Single<[String]> {
+    private func uploadNewImages(category: CommunitySectionType) -> Single<[String]> {
         let images = self.output.newPictures.value
         guard !images.isEmpty else { return .just([]) }
         let uploadType: UploadImageType = category == .invLogBoard ? .invLogBoard : .detectiveMate
@@ -403,14 +402,6 @@ final class AddNewContentViewModel {
                 }
             })
             .disposed(by: disposeBag)
-    }
-    
-    func getCollection(_ category: CommunityViewModel.CommunitySectionType) -> FirestoreCollection? {
-        if let collection = FirestoreCollection.allCases.filter({ category.collectionName == $0.rawValue }).first {
-            return collection
-        } else {
-            return nil
-        }
     }
     
     private func setAgeGenderStyle(data: PetProfile) -> String {

--- a/SherlDog/Scene/CommunityTab/ViewModel/AddNewContentViewModel.swift
+++ b/SherlDog/Scene/CommunityTab/ViewModel/AddNewContentViewModel.swift
@@ -320,11 +320,10 @@ final class AddNewContentViewModel {
                     postDate: post.postDate,
                     contentImage: merged,
                     content: self.text.value,
-                    like: post.like,
-                    previewComment: post.previewComment,
+                    likeCount: post.likeCount,
+                    commentCount: post.commentCount,
                     documentId: post.documentId
-                )
-
+                ) // TODO: 모델 자체를 넣는 것이 아닌 일부 프로퍼티만 변경하도록
                     
                 return FirestoreManager.shared.updateDocument(collection: collection,
                                                               documentId: post.documentId,

--- a/SherlDog/Scene/CommunityTab/ViewModel/CommunityViewModel.swift
+++ b/SherlDog/Scene/CommunityTab/ViewModel/CommunityViewModel.swift
@@ -229,23 +229,35 @@ extension CommunityViewModel {
         _ input: Observable<CommunityModel>,
         category: Observable<CommunitySectionType>
     ) -> Observable<Mutation> {
-        return input
+        
+        // 현재 isLiked 스트림
+        let isLikedStream = input
             .withLatestFrom(category) { ($0, $1) }
-            .flatMapFirst { [weak self] (model, category) -> Observable<Mutation> in
+            .flatMapLatest { [weak self] (model, category) -> Observable<Bool> in
                 guard let self,
                       let userId = Auth.auth().currentUser?.uid,
                       let collection = self.getCollection(category) else { return .empty() }
+                return CommunityActionManager.shared.isLiked(collection: collection, postCode: model.documentId, userId: userId)
+            }
+            .share(replay: 1)
+        
+        // 토글
+        return input
+            .withLatestFrom(Observable.combineLatest(category, isLikedStream)) { ($0, $1.0, $1.1) }
+            .flatMapFirst { [weak self] (model, category, isLiked) -> Observable<Mutation> in
+                guard let self, let collection = self.getCollection(category) else { return .empty() }
                 
-                let newLikes = model.like.contains(userId)
-                ? model.like.filter { $0 != userId }
-                : (model.like + [userId])
+                let newLikes = isLiked
+                ? model.likeCount - 1
+                : model.likeCount + 1
                 
                 var patched = model
-                patched.like = newLikes
+                patched.likeCount = newLikes
                 
-                return FirestoreManager.shared.updateDocument(collection: collection, documentId: model.documentId, data: patched)
-                    .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .background))
-                    .andThen(.just(Mutation.patch(category: category, post: patched)))
+                return CommunityActionManager.shared.toggleLikeWithCount(collection: collection,
+                                                                         postCode: model.documentId)
+                .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .background))
+                .andThen(.just(Mutation.patch(category: category, post: patched)))
             }
     }
 }

--- a/SherlDog/Scene/CommunityTab/ViewModel/CommunityViewModel.swift
+++ b/SherlDog/Scene/CommunityTab/ViewModel/CommunityViewModel.swift
@@ -11,27 +11,27 @@ import RxDataSources
 import Differentiator
 import FirebaseAuth
 
-final class CommunityViewModel {
+// 게시판 종류
+enum CommunitySectionType: CaseIterable {
+    case invLogBoard
+    case detectiveMateBoard
     
-    // 게시판 종류
-    enum CommunitySectionType: CaseIterable {
-        case invLogBoard
-        case detectiveMateBoard
-        
-        var name: String {
-            switch self {
-            case .invLogBoard:        return SDLiteral.CommunityView.invLogBoardTitle
-            case .detectiveMateBoard: return SDLiteral.CommunityView.detectiveMateTitle
-            }
-        }
-        
-        var collectionName: String {
-            switch self {
-            case .invLogBoard:        return FirestoreCollection.invLogBoard.rawValue
-            case .detectiveMateBoard: return FirestoreCollection.detectiveMate.rawValue
-            }
+    var name: String {
+        switch self {
+        case .invLogBoard:        return SDLiteral.CommunityView.invLogBoardTitle
+        case .detectiveMateBoard: return SDLiteral.CommunityView.detectiveMateTitle
         }
     }
+    
+    var toFirestoreCollection: FirestoreCollection {
+        switch self {
+        case .invLogBoard:        return .invLogBoard
+        case .detectiveMateBoard: return .detectiveMate
+        }
+    }
+}
+
+final class CommunityViewModel {
     
     // 데이터 변경 Mutation
     enum Mutation {
@@ -83,17 +83,18 @@ final class CommunityViewModel {
         let isUpdating = makeIsUpdating(refreshTrigger: refreshTrigger,
                                         fetchStream: fetchStream)
         
+        // Like Event
+        bindLikeSideEffect(input.likeEvent, category: selectedCategory)
+        
         // mutations
         let refreshMutation = makeRefreshMutation(postsEvent: fetchStream,
                                                   selectedCategory: selectedCategory)
         let appendMutation = makeAppendMutation(fetchMore: input.fetchMore,
                                                 selectedCategory: selectedCategory)
-        let likeMutation = like(input.likeEvent, category: selectedCategory)
         
         // state(store)
         let postsDict = makePostsDict(refreshMutation: refreshMutation,
-                                      appendMutation: appendMutation,
-                                      likeMutation: likeMutation)
+                                      appendMutation: appendMutation)
         let currentCellData = mapPostsToSections(postsDict)
         
         return Output(
@@ -182,13 +183,11 @@ private extension CommunityViewModel {
     
     // 상태(Store) 축적
     func makePostsDict(refreshMutation: Observable<Mutation>,
-                       appendMutation: Observable<Mutation>,
-                       likeMutation: Observable<Mutation>)
+                       appendMutation: Observable<Mutation>)
     -> Observable<[CommunitySectionType : [CommunityModel]]> {
         Observable.merge(
             refreshMutation,
-            appendMutation,
-            likeMutation
+            appendMutation
         )
             .scan(makeInitialPosts()) { dict, mutation in
                 var next = dict
@@ -223,54 +222,14 @@ private extension CommunityViewModel {
     }
 }
 
-// MARK: - Like Button Event
-extension CommunityViewModel {
-    private func like(
-        _ input: Observable<CommunityModel>,
-        category: Observable<CommunitySectionType>
-    ) -> Observable<Mutation> {
-        
-        // 현재 isLiked 스트림
-        let isLikedStream = input
-            .withLatestFrom(category) { ($0, $1) }
-            .flatMapLatest { [weak self] (model, category) -> Observable<Bool> in
-                guard let self,
-                      let userId = Auth.auth().currentUser?.uid,
-                      let collection = self.getCollection(category) else { return .empty() }
-                return CommunityActionManager.shared.isLiked(collection: collection, postCode: model.documentId, userId: userId)
-            }
-            .share(replay: 1)
-        
-        // 토글
-        return input
-            .withLatestFrom(Observable.combineLatest(category, isLikedStream)) { ($0, $1.0, $1.1) }
-            .flatMapFirst { [weak self] (model, category, isLiked) -> Observable<Mutation> in
-                guard let self, let collection = self.getCollection(category) else { return .empty() }
-                
-                let newLikes = isLiked
-                ? model.likeCount - 1
-                : model.likeCount + 1
-                
-                var patched = model
-                patched.likeCount = newLikes
-                
-                return CommunityActionManager.shared.toggleLikeWithCount(collection: collection,
-                                                                         postCode: model.documentId)
-                .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .background))
-                .andThen(.just(Mutation.patch(category: category, post: patched)))
-            }
-    }
-}
-
 // MARK: - Menu Button Event
 private extension CommunityViewModel {
     func menuButtonEvent(_ input: Observable<PostMenuEvent>,
                          category: Observable<CommunitySectionType>) -> Signal<PostMenuEvent> {
         input
             .withLatestFrom(category) { ($0, $1) }
-            .flatMapLatest { [weak self] (menu, category) -> Observable<PostMenuEvent> in
-                guard let self,
-                      let collection = self.getCollection(category) else { return .empty() }
+            .flatMapLatest { (menu, category) -> Observable<PostMenuEvent> in
+                let collection = category.toFirestoreCollection
                 
                 switch menu {
                 case .fix:
@@ -286,7 +245,7 @@ private extension CommunityViewModel {
                     .catchAndReturn(.error)
                     
                 case .report(let documentId):
-                    let reportData = ReportModel(collection: category.collectionName,
+                    let reportData = ReportModel(collection: category.toFirestoreCollection.rawValue,
                                                             documentId: documentId)
                     
                     return FirestoreManager.shared.createDocument(collection: .reportLog,
@@ -320,7 +279,7 @@ private extension CommunityViewModel {
     }
     
     func fetchPosts(category: CommunitySectionType) -> Single<[CommunityModel]> {
-        guard let collection = self.getCollection(category) else { return .error(FirestoreError.unknown) }
+        let collection = category.toFirestoreCollection
         
         return BlockManager.shared.fetchBlockedUsers()
             .flatMap { blocked in
@@ -376,12 +335,23 @@ private extension CommunityViewModel {
         return Single.zip(singles)
             .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .background))
     }
-    
-    func getCollection(_ category: CommunitySectionType) -> FirestoreCollection? {
-        if let collection = FirestoreCollection.allCases.filter({ category.collectionName == $0.rawValue }).first {
-            return collection
-        } else {
-            return nil
-        }
+}
+
+// MARK: - Like Event
+private extension CommunityViewModel {
+    func bindLikeSideEffect(_ input: Observable<CommunityModel>,
+                            category: Observable<CommunitySectionType>) {
+        input
+            .withLatestFrom(category) { ($0, $1) }
+            .flatMapFirst { (model, category) -> Completable in
+                let collection = category.toFirestoreCollection
+                return CommunityActionManager.shared.toggleLikeWithCount(
+                    collection: collection,
+                    postCode: model.documentId
+                )
+                .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .background))
+            }
+            .subscribe()
+            .disposed(by: disposeBag)
     }
 }

--- a/SherlDog/Scene/CommunityTab/ViewModel/PostFooterViewModel.swift
+++ b/SherlDog/Scene/CommunityTab/ViewModel/PostFooterViewModel.swift
@@ -1,0 +1,67 @@
+//
+//  PostFooterViewModel.swift
+//  SherlDog
+//
+//  Created by 최규현 on 9/16/25.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+import FirebaseAuth
+
+struct PostFooterLikeState {
+    let likeImage: UIImage?
+    let likeCountText: String
+}
+
+final class PostFooterViewModel {
+    
+    struct Input {
+        let likeTap: Signal<Void>
+    }
+    
+    struct Output {
+        let state: Driver<PostFooterLikeState>
+    }
+    
+    private let disposeBag = DisposeBag()
+
+    private let post: CommunityModel
+    private let category: FirestoreCollection
+
+    init(category: FirestoreCollection, post: CommunityModel) {
+        self.post = post
+        self.category = category
+    }
+    
+    func transform(input: Input) -> Output {
+        let userId = Auth.auth().currentUser?.uid ?? ""
+        
+        let isLiked = CommunityActionManager.shared.observeIsLiked(collection: self.category,
+                                                                   postCode: self.post.documentId,
+                                                                   userId: userId)
+            .distinctUntilChanged()
+            .share(replay: 1)
+
+        let likeCount = CommunityActionManager.shared.observeLikeCount(collection: self.category,
+                                                                       postCode: self.post.documentId)
+            .distinctUntilChanged()
+            .share(replay: 1)
+
+        let state = Observable.combineLatest(isLiked, likeCount)
+            .map { liked, count in
+                PostFooterLikeState(
+                    likeImage: liked
+                      ? UIImage(systemName:"heart.fill")?.withTintColor(.keycolorPrimary2, renderingMode:.alwaysOriginal)
+                      : UIImage(systemName:"heart")?.withTintColor(.gray900, renderingMode:.alwaysOriginal),
+                    likeCountText: count > 0 ? "\(count)" : ""
+                )
+            }
+            .asDriver(onErrorJustReturn: PostFooterLikeState(
+                likeImage: UIImage(systemName:"heart"),
+                likeCountText: ""))
+
+        return Output(state: state)
+    }
+}


### PR DESCRIPTION
close #367 

## *⛳️ Work Description*

- like, previewComment라는 컬렉션을 생성해 저장하도록 로직 변경

## *📸 Screenshot*

리팩토링이므로 스크린샷은 없습니다.

## *📢 To Reviewers*

- Like observer를 추가해 현재 내가 보고 있는 cell에 해당하는 Post의 Like는 실시간 업데이트 됩니다.
- Comment 관련 CRUD 메서드도 생성해 뒀습니다

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
