### PR TITLE
[Fix] 수사일지 아카이브 편집모드 관련 버그 fix, 오탈자 수정

### DIFF
--- a/SherlDog/Resources/SDLiteral.swift
+++ b/SherlDog/Resources/SDLiteral.swift
@@ -72,6 +72,7 @@ enum SDLiteral {
         static let deleteButton: String = "삭제"
         static let deleteComplete: String = "삭제되었습니다."
         static let requestDelete: String = "수사일지를 삭제하시겠습니까?"
+        static let requestDeleteWithoutList: String = "선택된 수사일지가 없습니다."
         static let caseNumber: String = "CASE # %@"
         static let infoLabel: String = "%@  ·  %@  ·  %@"
         static let onboardingUserDefaults: String = "needOnboardingInvLogArchive"

--- a/SherlDog/Scene/CommunityTab/View/CommunityViewController.swift
+++ b/SherlDog/Scene/CommunityTab/View/CommunityViewController.swift
@@ -236,7 +236,7 @@ extension CommunityViewController {
             message: String(format: SDLiteral.CommunityView.completeAlert, message),
             buttons: [
                 CustomAlertViewController.AlertButton(
-                    title: SDLiteral.AlertMessage.cancel,
+                    title: SDLiteral.AlertMessage.confirm,
                     action: nil
                 )
             ]

--- a/SherlDog/Scene/MyPageTab/View/ViewControll/InvLogListViewController.swift
+++ b/SherlDog/Scene/MyPageTab/View/ViewControll/InvLogListViewController.swift
@@ -88,6 +88,22 @@ extension InvLogListViewController {
             }
             .disposed(by: disposeBag)
         
+        self.viewModel.output.cellData
+            .map { data -> Bool in
+                guard let section = data.first else { return false }
+                
+                return section.items.count > 0
+            }
+            .asDriver(onErrorJustReturn: false)
+            .drive(onNext: { [weak self] state in
+                self?.modeConvertButton.isEnabled = state
+                
+                state
+                ? self?.modeConvertButton.setTitleColor(.textAlert, for: .normal)
+                : self?.modeConvertButton.setTitleColor(.textDisabled, for: .normal)
+            })
+            .disposed(by: disposeBag)
+        
         self.viewModel.output.deleteCompleted
             .bind(onNext: { [weak self] in
                 let alert = CustomAlertViewController(
@@ -95,7 +111,9 @@ extension InvLogListViewController {
                     buttons: [
                         CustomAlertViewController.AlertButton(
                             title: SDLiteral.AlertMessage.confirm,
-                            action: nil
+                            action: { [weak self] in
+                                self?.viewModel.input.accept(.selectModeConvert)
+                            }
                         )
                     ]
                 )
@@ -129,7 +147,7 @@ extension InvLogListViewController {
                     self?.onboardingView.alpha = 0
                 }, completion: { _ in
                     self?.onboardingView.isHidden = true
-                    self?.onboardingView.alpha = 1   // 다음번 다시 보여줄 때 대비
+                    self?.onboardingView.alpha = 1
                 })
             }
             .disposed(by: disposeBag)
@@ -151,24 +169,42 @@ extension InvLogListViewController {
         .disposed(by: disposeBag)
         
         self.deleteButton.rx.tap
-            .bind { [weak self] in
-                let alert = CustomAlertViewController(
-                    message: SDLiteral.InvLogListView.requestDelete,
-                     buttons: [
-                         CustomAlertViewController.AlertButton(
-                            title: SDLiteral.AlertMessage.cancel,
-                             action: nil
-                         ),
-                         CustomAlertViewController.AlertButton(
+            .map { [weak self] _ -> [IndexPath] in
+                guard let self,
+                       let indexPaths = self.collectionView.indexPathsForSelectedItems else { return [] }
+                
+                return indexPaths
+            }
+            .bind { [weak self] indexPaths in
+                let buttons: [CustomAlertViewController.AlertButton]
+                
+                if indexPaths.count > 0 {
+                    buttons = [
+                        CustomAlertViewController.AlertButton(
+                           title: SDLiteral.AlertMessage.cancel,
+                            action: nil
+                        ),
+                        CustomAlertViewController.AlertButton(
+                           title: SDLiteral.AlertMessage.confirm,
+                            action: { [weak self] in
+                                self?.viewModel.input.accept(.delete(indexPaths))
+                            }
+                        )
+                    ]
+                } else {
+                    buttons = [
+                        CustomAlertViewController.AlertButton(
                             title: SDLiteral.AlertMessage.confirm,
-                             action: { [weak self] in
-                                 guard let self,
-                                        let indexPaths = self.collectionView.indexPathsForSelectedItems else { return }
-                                 
-                                 self.viewModel.input.accept(.delete(indexPaths))
-                             }
-                         )
-                     ]
+                            action: nil
+                        )
+                    ]
+                }
+                
+                let alert = CustomAlertViewController(
+                    message: indexPaths.count > 0
+                    ? SDLiteral.InvLogListView.requestDelete
+                    : SDLiteral.InvLogListView.requestDeleteWithoutList,
+                     buttons: buttons
                  )
                 
                 self?.present(alert, animated: true)


### PR DESCRIPTION
close #372 

## *⛳️ Work Description*

- 수사일지가 없으면 편집 버튼 비활성화
- 편집모드에서 수사일지를 선택하지 않으면 삭제 알럿이 띄워지지 않도록 수정
- 차단 알럿 complete 버튼 오탈자 수정

## *📸 Screenshot*

| before | After | 
| -- | -- |
| <img src="https://github.com/user-attachments/assets/f7008b65-df49-4a7e-a868-8dafd79588da"  width="300"/> | <img src="https://github.com/user-attachments/assets/695a0130-a723-418f-8846-f18fc5a31521"  width="300"/> |
| <img src="https://github.com/user-attachments/assets/b2296446-b50c-49bc-98a3-b251a71d8b89"  width="300"/> | <img src="https://github.com/user-attachments/assets/01caea0c-f327-4dd3-b6d5-96eff5bc04dc"  width="300"/> |

## *📢 To Reviewers*

- 

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
