### PR TITLE
[Fix] 탐정메이트 데이터 불러오기 에러 처리

### DIFF
--- a/SherlDog/Scene/CommunityTab/ViewModel/CommunityViewModel.swift
+++ b/SherlDog/Scene/CommunityTab/ViewModel/CommunityViewModel.swift
@@ -191,24 +191,24 @@ private extension CommunityViewModel {
             refreshMutation,
             appendMutation
         )
-            .scan(makeInitialPosts()) { dict, mutation in
-                var next = dict
-                switch mutation {
-                case let .set(category, posts):
-                    next[category] = posts
-                case let .append(category, posts):
-                    next[category, default: []] += posts
-                case let .patch(category, post):
-                    var data = next[category, default: []]
-                    if let index = data.firstIndex(where: { $0.documentId == post.documentId }) {
-                        data[index] = post
-                    }
-                    
-                    next[category] = data
+        .scan(makeInitialPosts()) { dict, mutation in
+            var next = dict
+            switch mutation {
+            case let .set(category, posts):
+                next[category] = posts
+            case let .append(category, posts):
+                next[category, default: []] += posts
+            case let .patch(category, post):
+                var data = next[category, default: []]
+                if let index = data.firstIndex(where: { $0.documentId == post.documentId }) {
+                    data[index] = post
                 }
-                return next
+                
+                next[category] = data
             }
-            .share(replay: 1)
+            return next
+        }
+        .share(replay: 1)
     }
     
     // 섹션 매핑 → Driver
@@ -248,11 +248,11 @@ private extension CommunityViewModel {
                     
                 case .report(let documentId):
                     let reportData = ReportModel(collection: category.toFirestoreCollection.rawValue,
-                                                            documentId: documentId)
+                                                 documentId: documentId)
                     
                     return FirestoreManager.shared.createDocument(collection: .reportLog,
-                                                           data: reportData,
-                                                           documentId: documentId)
+                                                                  data: reportData,
+                                                                  documentId: documentId)
                     .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .background))
                     .andThen(.just(.report(documentId)))
                     .catchAndReturn(.error)
@@ -285,7 +285,8 @@ private extension CommunityViewModel {
         
         return BlockManager.shared.fetchBlockedUserIds()
             .flatMap { blocked in
-                return FirestoreManager.shared.fetchQuery(FirestoreQuery<CommunityModel>(
+                return FirestoreManager.shared.fetchQuery(
+                    FirestoreQuery<CommunityModel>(
                     collection: collection,
                     type: .collection(sortField: SDLiteral.CommunityView.postDate,
                                       descending: true,
@@ -302,33 +303,31 @@ private extension CommunityViewModel {
     
     func fetchProfiles(_ data: [CommunityModel]) -> Single<[CommunityModel]> {
         let singles = data.map { postData in
-            let pets = postData.petProfile.map { pet in
-                FirestoreManager.shared.fetchQuery(FirestoreQuery<PetProfile>(
+            let pets: [Single<PetProfile?>] = postData.petProfile.map { pet in
+                FirestoreManager.shared.fetchQuery(
+                    FirestoreQuery<PetProfile>(
                     collection: .petProfile,
                     type: .document(id: pet.petProfileId)
                 ))
-                .flatMap { profile -> Single<PetProfile> in
-                    guard let profile = profile.first else { return .error(FirestoreError.noData) }
-                    return .just(profile)
-                }
+                .map { $0.first }
+                .catch { _ in .just(nil) }
             }
             
-            let human = FirestoreManager.shared.fetchQuery(FirestoreQuery<HumanProfileModel>(
+            let human: Single<HumanProfileModel?> =
+            FirestoreManager.shared.fetchQuery(FirestoreQuery<HumanProfileModel>(
                 collection: .humanProfile,
                 type: .document(id: postData.userId)
             ))
-                .flatMap { profile -> Single<HumanProfileModel> in
-                    guard let profile = profile.first else { return .error(FirestoreError.noData) }
-                    return .just(profile)
-                }
+            .map { $0.first }
+            .catch { _ in .just(nil) }
             
-            let petZip = Single.zip(pets)
+            let petZip: Single<[PetProfile]> = Single.zip(pets).map { $0.compactMap { $0 } }
             
             return Single.zip(human, petZip)
-                .map { human, pet in
+                .map { humanOpt, pet in
                     var post = postData
-                    post.name = human.nickname
-                    post.profileImage = human.image
+                    post.name = humanOpt?.nickname ?? "사용자"
+                    post.profileImage = humanOpt?.image ?? ""
                     post.petProfile = pet
                     return post
                 }


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

- 탐정메이트 데이터 불러오기 에러 처리 입니다.
저번 코드 작성 때는 문제 없이 탐정메이트 작성 글 데이터가 잘 불러와졌는데 갑자기 오류가 나서 보니 

```
.flatMap { profile -> Single<PetProfile> in
    guard let profile = profile.first else { return .error(FirestoreError.noData) }
    return .just(profile)
}

```
여기서 사용되는 싱글 집코드가 하나라도 에러면 전체 zip이 실패 처리가 돼서 리스트가 통째로 들어오지 않는다는 이슈가 있었다고 합니다. 그래서 에러 처리 대신 nil 반환하고, 기본값 추가해서 수정해두니 데이터가 잘 들어옵니다.

여전히 그때는 맞고 지금은 틀린지는 미궁 속에 있습니다...!

## *📸 Screenshot*

코드 수정이기 때문에 UI 변화는 없습니다.

## *📢 To Reviewers*

- 리뷰어에게 하고 싶은 말

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
