### PR TITLE
[Fix] 각 탭의 메인화면에서 한 단계 더 들어가면 바텀탭바 보이지 않게 처리

### DIFF
--- a/SherlDog/Scene/CommunityTab/View/CommunityViewController.swift
+++ b/SherlDog/Scene/CommunityTab/View/CommunityViewController.swift
@@ -71,7 +71,9 @@ extension CommunityViewController {
         self.addButton.rx.tap
             .asSignal()
             .emit(onNext: { [weak self] in
-                self?.navigationController?.pushViewController(AddNewContentViewController(), animated: true)
+                let addNewContentViewController = AddNewContentViewController()
+                addNewContentViewController.hidesBottomBarWhenPushed = true
+                self?.navigationController?.pushViewController(addNewContentViewController, animated: true)
             })
             .disposed(by: disposeBag)
         
@@ -133,6 +135,7 @@ extension CommunityViewController {
             }()
             
             let editView = AddNewContentViewController(category: category, post: post)
+            editView.hidesBottomBarWhenPushed = true
             self?.navigationController?.pushViewController(editView, animated: true)
         }
         
@@ -297,6 +300,7 @@ extension CommunityViewController {
                             // TODO: 프로필 뷰로 이동
                             let authorUserId = sectionModel.userId
                             let userProfileViewComtroll = UserProfileViewController(userId: authorUserId)
+                            userProfileViewComtroll.hidesBottomBarWhenPushed = true
                             self?.navigationController?.pushViewController(userProfileViewComtroll, animated: true)
                         })
                         .disposed(by: header.disposeBag)

--- a/SherlDog/Scene/MyPageTab/View/ViewControll/MyPageViewController.swift
+++ b/SherlDog/Scene/MyPageTab/View/ViewControll/MyPageViewController.swift
@@ -207,6 +207,7 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
                 guard let self else { return }
                 
                 let archiveView = InvLogListViewController()
+                archiveView.hidesBottomBarWhenPushed = true
                 self.navigationController?.pushViewController(archiveView, animated: true)
             })
             .disposed(by: disposeBag)
@@ -216,6 +217,7 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
                 guard let self else { return }
                 
                 let findMateViewController = FindMateViewController()
+                findMateViewController.hidesBottomBarWhenPushed = true
                 self.navigationController?
                     .pushViewController(findMateViewController, animated: true)
             })
@@ -224,6 +226,7 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
         mypageSettingButton.rx.tap
             .bind { [weak self] in
                 let settingVC = SettingViewController()
+                settingVC.hidesBottomBarWhenPushed = true
                 self?.navigationController?.pushViewController(settingVC, animated: true)
             }
             .disposed(by: disposeBag)
@@ -250,6 +253,7 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
                 if let profile = humanProfile {
                     createAssistantVC.configure(with: profile)
                 }
+                createAssistantVC.hidesBottomBarWhenPushed = true
                 self.navigationController?.pushViewController(createAssistantVC, animated: true)
             }
             .disposed(by: disposeBag)


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

- 각 탭의 메인화면에서 한 단계 더 들어가면 바텀탭바 보이지 않게 처리했습니다! 
- 뷰컨을 푸시하는 코드에서 푸시하기 전에 뷰컨.hidesBottomBarWhenPushed = true 를 해주면 간단하게 처리할 수 있는 거였습니다!
- 아마 다른 뷰들도 연결 후 한 번 더 점검해봐야 할 것 같습니다만, 현재 필요한 부분에는 모두 처리했습니다!

## *📸 Screenshot*

| before | After | 
| -- | -- |
|  | ![Simulator Screen Recording - iPhone 13 mini - 2025-11-03 at 17 20 13](https://github.com/user-attachments/assets/7ca522a0-a90f-42e5-9302-4ddc80d804bc) |

## *📢 To Reviewers*

- 리뷰어에게 하고 싶은 말

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
