### PR TITLE
[Fix] [Fix] 차단한 사용자 선택 안 해도 차단되는 이슈 해결

### DIFF
--- a/SherlDog/Resources/SDLiteral.swift
+++ b/SherlDog/Resources/SDLiteral.swift
@@ -84,6 +84,7 @@ enum SDLiteral {
         static let navigationCancelButton: String = "취소"
         static let navigationUnblockButton: String = "차단 해제"
         static let emptyStateLabel: String = "차단한 사용자가 없습니다."
+        static let emptySelectedUnblockUsersAlertText: String = "선택된 차단 유저가 없습니다."
         static let unblcockAlertText: String = "선택한 사용자를\n차단 해제하시겠습니까?"
     }
     

--- a/SherlDog/Scene/MyPageTab/View/ViewControll/BlockedUserViewController.swift
+++ b/SherlDog/Scene/MyPageTab/View/ViewControll/BlockedUserViewController.swift
@@ -34,7 +34,6 @@ class BlockedUserViewController: UIViewController {
         setupUI()
         configureUI()
         bind()
-        
         viewModel.fetchBlockedUsers()
     }
     
@@ -75,23 +74,33 @@ class BlockedUserViewController: UIViewController {
             .disposed(by: disposeBag)
         
         unblockButton.rx.tap
-            .bind { [weak self] in
-                let alert = CustomAlertViewController(
+            .withLatestFrom(viewModel.selectedIndexes.asObservable())
+            .observe(on: MainScheduler.instance)
+            .bind { [weak self] selected in
+                guard let self = self else { return }
+
+                if selected.isEmpty {
+                    let alert = CustomAlertViewController(
+                        message: SDLiteral.BlockedUserViewController.emptySelectedUnblockUsersAlertText,
+                        buttons: [
+                            .init(title: SDLiteral.AlertMessage.confirm, action: nil)
+                        ]
+                    )
+                    self.present(alert, animated: true)
+                    return
+                }
+
+                let confirm = CustomAlertViewController(
                     message: SDLiteral.BlockedUserViewController.unblcockAlertText,
                     buttons: [
-                        CustomAlertViewController.AlertButton(
-                            title: SDLiteral.AlertMessage.cancel,
-                            action: nil
-                        ),
-                        CustomAlertViewController.AlertButton(
-                            title: SDLiteral.AlertMessage.confirm,
-                            action: { [weak self] in
-                                self?.viewModel.unblockSelectedUsers()
-                                self?.viewModel.setEditing(false)
-                            }
-                        )
-                    ])
-                self?.present(alert, animated: true, completion: nil)
+                        .init(title: SDLiteral.AlertMessage.cancel, action: nil),
+                        .init(title: SDLiteral.AlertMessage.confirm, action: { [weak self] in
+                            self?.viewModel.unblockSelectedUsers()
+                            self?.viewModel.setEditing(false)
+                        })
+                    ]
+                )
+                self.present(confirm, animated: true)
             }
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

- 차단한 사용자 선택 안 해도 차단되는 이슈 해결했습니다.
- 산책일지 삭제UI와 동일하게 아무 것도 선택하지 않은 채로 차단해제 버튼을 누를 시 알럿이 뜹니다
- 아예 버튼을 비활성화 시켜놓는 것이 UX적으로 더 익숙하고 UI적으로도 더 직관적일 것 같습니다만...하핫
- 수정하면서 생각나서 일단은 기존에 합의된 방식으로 수정했습니다. (_ _) 

## *📸 Screenshot*

| before | After | 
| -- | -- |
|  | ![Simulator Screen Recording - iPhone 13 mini - 2025-11-03 at 17 33 02](https://github.com/user-attachments/assets/9cb99436-003d-40ec-a387-b2730b85d1c1) |

## *📢 To Reviewers*

- 리뷰어에게 하고 싶은 말

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
