### PR TITLE
[Fix] 바텀탭바에서 커뮤니티 다시 가리기 및 각종 View에서 커뮤니티 숨기기

### DIFF
--- a/SherlDog/Reusable/Component/BottomTabBarController.swift
+++ b/SherlDog/Reusable/Component/BottomTabBarController.swift
@@ -10,13 +10,13 @@ import UIKit
 class BottomTabBarController: UITabBarController {
     
     let mainVC = UINavigationController(rootViewController: MainViewController())
-    let communityVC = UINavigationController(rootViewController: CommunityViewController())
+    // let communityVC = UINavigationController(rootViewController: CommunityViewController())
     let myPageVC = UINavigationController(rootViewController: MyPageViewController())
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let controllers = [mainVC, communityVC, myPageVC]
+        let controllers = [mainVC,/*communityVC,*/ myPageVC]
         self.viewControllers = controllers
         
         self.navigationItem.hidesBackButton = true
@@ -31,9 +31,9 @@ class BottomTabBarController: UITabBarController {
                                       image: UIImage(named: "home")?.resized(to: CGSize(width: 32, height: 32)),tag: 0)
         mainVC.tabBarItem.selectedImage = UIImage(named: "homeGreen")?.resized(to: CGSize(width: 32, height: 32)).withRenderingMode(.alwaysOriginal)
         
-        communityVC.tabBarItem = UITabBarItem(title: "수사일지",
-                                      image: UIImage(named: "community")?.resized(to: CGSize(width: 32, height: 32)),tag: 1)
-        communityVC.tabBarItem.selectedImage = UIImage(named: "communityGreen")?.resized(to: CGSize(width: 32, height: 32)).withRenderingMode(.alwaysOriginal)
+//        communityVC.tabBarItem = UITabBarItem(title: "수사일지",
+//                                      image: UIImage(named: "community")?.resized(to: CGSize(width: 32, height: 32)),tag: 1)
+//        communityVC.tabBarItem.selectedImage = UIImage(named: "communityGreen")?.resized(to: CGSize(width: 32, height: 32)).withRenderingMode(.alwaysOriginal)
         
         myPageVC.tabBarItem = UITabBarItem(title: "마이",
                                       image: UIImage(named: "myPage")?.resized(to: CGSize(width: 32, height: 32)),tag: 2)

--- a/SherlDog/Scene/MyPageTab/View/ViewControll/MyPageViewController.swift
+++ b/SherlDog/Scene/MyPageTab/View/ViewControll/MyPageViewController.swift
@@ -26,7 +26,7 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
     let assistantLabel = UILabel()
     let assistantButton = UIButton()
     let archiveButton = UIButton()
-    let findMateButton = UIButton()
+//    let findMateButton = UIButton()
     let buttonStack = UIStackView()
     
     // 멍탐정 카드 collectionItem
@@ -57,10 +57,10 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        let topLine = CALayer()
-        topLine.backgroundColor = UIColor(named: "gray200")?.cgColor
-        topLine.frame = CGRect(x: 0, y: 0, width: findMateButton.bounds.width, height: 1)
-        findMateButton.layer.addSublayer(topLine)
+//        let topLine = CALayer()
+//        topLine.backgroundColor = UIColor(named: "gray200")?.cgColor
+//        topLine.frame = CGRect(x: 0, y: 0, width: findMateButton.bounds.width, height: 1)
+//        findMateButton.layer.addSublayer(topLine)
     }
     
     private func setupUI() {
@@ -72,7 +72,7 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
             collectionView,
             pageControl,
             archiveButton,
-            findMateButton,
+//            findMateButton,
             buttonStack,
             mypageSettingButton
         ].forEach {
@@ -125,7 +125,7 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
         buttonStack.distribution = .fillEqually
         buttonStack.spacing = 0
         buttonStack.addArrangedSubview(archiveButton)
-        buttonStack.addArrangedSubview(findMateButton)
+//        buttonStack.addArrangedSubview(findMateButton)
         
         archiveButton.setTitle(SDLiteral.MyPageViewController.archiveButtonTitle, for: .normal)
         archiveButton.titleLabel?.font = .body3
@@ -136,22 +136,22 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
         archiveButton.contentHorizontalAlignment = .left
         archiveButton.setContentInsets(.init(top: 16, leading: 16, bottom: 16, trailing: 16))
         archiveButton.layer.cornerRadius = 12
-        archiveButton.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+//        archiveButton.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         archiveButton.clipsToBounds = true
         archiveButton.setTitleInsets(.init(top: 0, left: 8, bottom: 0, right: -8))
         
-        findMateButton.setTitle(SDLiteral.MyPageViewController.findMateButtonTitle, for: .normal)
-        findMateButton.titleLabel?.font = .body3
-        findMateButton.setTitleColor(.textPrimary, for: .normal)
-        findMateButton.setTitleColor(.textPrimary, for: .highlighted)
-        findMateButton.backgroundColor = .gray100
-        findMateButton.setImage(UIImage(named: SDLiteral.MyPageViewController.findMateButtonImage), for: .normal)
-        findMateButton.contentHorizontalAlignment = .left
-        findMateButton.setContentInsets(.init(top: 16, leading: 16, bottom: 16, trailing: 16))
-        findMateButton.layer.cornerRadius = 12
-        findMateButton.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
-        findMateButton.clipsToBounds = true
-        findMateButton.setTitleInsets(.init(top: 0, left: 8, bottom: 0, right: -8))
+//        findMateButton.setTitle(SDLiteral.MyPageViewController.findMateButtonTitle, for: .normal)
+//        findMateButton.titleLabel?.font = .body3
+//        findMateButton.setTitleColor(.textPrimary, for: .normal)
+//        findMateButton.setTitleColor(.textPrimary, for: .highlighted)
+//        findMateButton.backgroundColor = .gray100
+//        findMateButton.setImage(UIImage(named: SDLiteral.MyPageViewController.findMateButtonImage), for: .normal)
+//        findMateButton.contentHorizontalAlignment = .left
+//        findMateButton.setContentInsets(.init(top: 16, leading: 16, bottom: 16, trailing: 16))
+//        findMateButton.layer.cornerRadius = 12
+//        findMateButton.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+//        findMateButton.clipsToBounds = true
+//        findMateButton.setTitleInsets(.init(top: 0, left: 8, bottom: 0, right: -8))
     }
     
     private func configureUI() {
@@ -197,7 +197,7 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
         buttonStack.snp.makeConstraints {
             $0.top.equalTo(pageControl.snp.bottom).offset(20)
             $0.leading.trailing.equalToSuperview().inset(16)
-            $0.height.equalTo(120)
+            $0.height.equalTo/*(120)*/(60)
         }
     }
     
@@ -212,16 +212,16 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
             })
             .disposed(by: disposeBag)
         
-        findMateButton.rx.tap
-            .bind(onNext: { [weak self] in
-                guard let self else { return }
-                
-                let findMateViewController = FindMateViewController()
-                findMateViewController.hidesBottomBarWhenPushed = true
-                self.navigationController?
-                    .pushViewController(findMateViewController, animated: true)
-            })
-            .disposed(by: disposeBag)
+//        findMateButton.rx.tap
+//            .bind(onNext: { [weak self] in
+//                guard let self else { return }
+//                
+//                let findMateViewController = FindMateViewController()
+//                findMateViewController.hidesBottomBarWhenPushed = true
+//                self.navigationController?
+//                    .pushViewController(findMateViewController, animated: true)
+//            })
+//            .disposed(by: disposeBag)
         
         mypageSettingButton.rx.tap
             .bind { [weak self] in

--- a/SherlDog/Scene/MyPageTab/View/ViewControll/SettingViewController.swift
+++ b/SherlDog/Scene/MyPageTab/View/ViewControll/SettingViewController.swift
@@ -26,9 +26,9 @@ class SettingViewController : UIViewController {
     private let withdrawStack = UIStackView()
     private let withdrawLabel = UILabel()
     private let withdrawButton = UIButton()
-    private let blockedUserStack = UIStackView()
-    private let blockedUserLabel = UILabel()
-    private let blockedUserButton = UIButton()
+//    private let blockedUserStack = UIStackView()
+//    private let blockedUserLabel = UILabel()
+//    private let blockedUserButton = UIButton()
     private let spacer = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
     private let settingBackStack = UIStackView()
     private let settingBackButton = UIButton()
@@ -75,9 +75,9 @@ class SettingViewController : UIViewController {
             withdrawStack,
             withdrawLabel,
             withdrawButton,
-            blockedUserStack,
-            blockedUserLabel,
-            blockedUserButton
+//            blockedUserStack,
+//            blockedUserLabel,
+//            blockedUserButton
         ].forEach {
             view.addSubview($0)
         }
@@ -138,16 +138,16 @@ class SettingViewController : UIViewController {
         withdrawStack.addArrangedSubview(withdrawLabel)
         withdrawStack.addArrangedSubview(withdrawButton)
         
-        blockedUserLabel.text = "차단한 사용자 목록"
-        blockedUserLabel.font = .body1
-        blockedUserLabel.textColor = .textPrimary
-        blockedUserButton.setImage(UIImage(named: "rightChevron"), for: .normal)
-        
-        blockedUserStack.axis = .horizontal
-        blockedUserStack.spacing = 50
-        blockedUserStack.alignment = .leading
-        blockedUserStack.addArrangedSubview(blockedUserLabel)
-        blockedUserStack.addArrangedSubview(blockedUserButton)
+//        blockedUserLabel.text = "차단한 사용자 목록"
+//        blockedUserLabel.font = .body1
+//        blockedUserLabel.textColor = .textPrimary
+//        blockedUserButton.setImage(UIImage(named: "rightChevron"), for: .normal)
+//        
+//        blockedUserStack.axis = .horizontal
+//        blockedUserStack.spacing = 50
+//        blockedUserStack.alignment = .leading
+//        blockedUserStack.addArrangedSubview(blockedUserLabel)
+//        blockedUserStack.addArrangedSubview(blockedUserButton)
         
         spacer.width = -8
         
@@ -168,7 +168,7 @@ class SettingViewController : UIViewController {
         
         withdrawStack.addSubview(withdrawWholeButton)
         
-        blockedUserStack.addSubview(blockedUserWholeButton)
+//        blockedUserStack.addSubview(blockedUserWholeButton)
         
     }
     
@@ -198,10 +198,10 @@ class SettingViewController : UIViewController {
             $0.leading.trailing.equalToSuperview().inset(16)
         }
         
-        blockedUserStack.snp.makeConstraints {
-            $0.top.equalTo(withdrawStack.snp.bottom).offset(34)
-            $0.leading.trailing.equalToSuperview().inset(16)
-        }
+//        blockedUserStack.snp.makeConstraints {
+//            $0.top.equalTo(withdrawStack.snp.bottom).offset(34)
+//            $0.leading.trailing.equalToSuperview().inset(16)
+//        }
 
         clauseWholeButton.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -215,9 +215,9 @@ class SettingViewController : UIViewController {
             $0.edges.equalToSuperview()
         }
         
-        blockedUserWholeButton.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
+//        blockedUserWholeButton.snp.makeConstraints {
+//            $0.edges.equalToSuperview()
+//        }
     }
     
     private func updateLoginStatus() {


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

- 바텀탭바, 마이페이지, 설정에서 커뮤니티 관련 기능 숨겨놨습니다!
- 
## *📸 Screenshot*

| 마이페이지 | 설정 | 
| -- | -- |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-02-17 at 09 41 55" src="https://github.com/user-attachments/assets/73d19480-f707-46ed-ac02-d556c9a1943a" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-02-17 at 09 41 57" src="https://github.com/user-attachments/assets/d2a5b20e-992b-43b5-a6c2-9d4c13a68c59" /> |

*바텀탭바 확인 해주심 됩니다!*

## *📢 To Reviewers*

- 새해 복 마니 받으세용~~

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
