### PR TITLE
[Fix] iOS26 glass material 없애는 코드 적용

### DIFF
--- a/SherlDog/Resources/Info.plist
+++ b/SherlDog/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

- Apple의 공식 문서에 따르면, UIDesignRequiresCompatibility는 UI의 호환성 모드 사용 여부를 나타내는 Boolean 값입니다. 이 키를 사용하면 최신 SDK의 새로운 UI 디자인을 적용하지 않고, 이전 버전의 SDK로 빌드한 것처럼 앱의 UI를 표시할 수 있습니다. 

출처: https://huisoo.tistory.com/30

## *📸 Screenshot*

| before | After | 
| -- | -- |
| <img width="590" height="1278" alt="IMG_7446" src="https://github.com/user-attachments/assets/19cad4da-577b-4961-a05e-38a5e79ff83e" /> | <img width="590" height="1278" alt="IMG_7611" src="https://github.com/user-attachments/assets/6fa97c9f-5091-4f81-9934-5bc670dc147a" /> |
| <img width="590" height="1278" alt="IMG_7447" src="https://github.com/user-attachments/assets/8844f6d0-658e-40b1-97f0-ad3ba33b4ae1" /> | <img width="590" height="1278" alt="IMG_7613" src="https://github.com/user-attachments/assets/75f03e45-02d0-4c05-b426-d63516588e3d" /> |
| <img width="590" height="1278" alt="IMG_7449" src="https://github.com/user-attachments/assets/5a0376b7-f96d-45fd-9214-5de94035d241" /> | <img width="590" height="1278" alt="IMG_7614" src="https://github.com/user-attachments/assets/b7a84ae8-8ab0-4b35-819b-83dfd47de41e" /> |
| <img width="590" height="1278" alt="IMG_7448" src="https://github.com/user-attachments/assets/98710c11-0cd5-4079-8ec4-f364916f79de" /> | <img width="590" height="1278" alt="IMG_7612" src="https://github.com/user-attachments/assets/06f8f53e-10ae-48d5-9417-33e5267f2d59" /> |

## *📢 To Reviewers*

- 리뷰어에게 하고 싶은 말

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
