### PR TITLE
[Refactor] Retain Cycle 개선 및 Firebase 코드 분리

### DIFF
--- a/SherlDog/Firebase/Auth/AuthManager.swift
+++ b/SherlDog/Firebase/Auth/AuthManager.swift
@@ -6,8 +6,19 @@
 //
 
 import Foundation
+import UIKit
 import FirebaseAuth
+import FirebaseFirestore
 import GoogleSignIn
+import KakaoSDKUser
+import KakaoSDKAuth
+import AuthenticationServices
+
+private struct AppleUserInfo {
+    let userIdentifier: String
+    let fullName: String?
+    let email: String?
+}
 
 final class AuthManager {
     
@@ -23,7 +34,189 @@ final class AuthManager {
         return Auth.auth().currentUser?.uid
     }
     
-    // 로그아웃
+    // MARK: - Login
+    
+    func loginWithKakao(completion: @escaping (Result<Void, Error>) -> Void) {
+        let completionBlock: (OAuthToken?, Error?) -> Void = { token, error in
+            if let error = error {
+                DispatchQueue.main.async {
+                    completion(.failure(error))
+                }
+                return
+            }
+            
+            guard token != nil else {
+                DispatchQueue.main.async {
+                    completion(.failure(NSError(domain: "AuthManager", code: -1, userInfo: [NSLocalizedDescriptionKey: "카카오 인증 토큰을 가져오지 못했습니다."])))
+                }
+                return
+            }
+            
+            UserApi.shared.me { user, error in
+                if let error = error {
+                    DispatchQueue.main.async {
+                        completion(.failure(error))
+                    }
+                    return
+                }
+                
+                guard let user else {
+                    DispatchQueue.main.async {
+                        completion(.failure(NSError(domain: "AuthManager", code: -1, userInfo: [NSLocalizedDescriptionKey: "사용자 정보를 가져올 수 없습니다."])))
+                    }
+                    return
+                }
+                
+                let userInfo = KakaoUserInfo(from: user)
+                let appUserId = AppUserID.fromKakaoID(userInfo.id)
+                
+                Auth.auth().signInAnonymously { [weak self] authResult, error in
+                    guard let self else { return }
+                    
+                    if let error = error {
+                        DispatchQueue.main.async {
+                            completion(.failure(error))
+                        }
+                        return
+                    }
+                    
+                    guard let firebaseUser = authResult?.user else {
+                        DispatchQueue.main.async {
+                            completion(.failure(NSError(domain: "AuthManager", code: -1, userInfo: [NSLocalizedDescriptionKey: "Firebase 인증 실패"])))
+                        }
+                        return
+                    }
+                    
+                    self.saveKakaoUserToFirestore(
+                        firebaseUser: firebaseUser,
+                        kakaoUserInfo: userInfo,
+                        appUserId: appUserId,
+                        completion: completion
+                    )
+                }
+            }
+        }
+        
+        if UserApi.isKakaoTalkLoginAvailable() {
+            UserApi.shared.loginWithKakaoTalk(completion: completionBlock)
+        } else {
+            UserApi.shared.loginWithKakaoAccount(completion: completionBlock)
+        }
+    }
+    
+    func loginWithGoogle(
+        presentingViewController: UIViewController,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        GIDSignIn.sharedInstance.signIn(withPresenting: presentingViewController) { [weak self] result, error in
+            guard let self else { return }
+            
+            if let error = error {
+                DispatchQueue.main.async {
+                    completion(.failure(error))
+                }
+                return
+            }
+            
+            guard
+                let user = result?.user,
+                let idToken = user.idToken?.tokenString
+            else {
+                DispatchQueue.main.async {
+                    completion(.failure(NSError(domain: "AuthManager", code: -1, userInfo: [NSLocalizedDescriptionKey: "인증 토큰을 가져오지 못했습니다"])))
+                }
+                return
+            }
+            
+            let credential = GoogleAuthProvider.credential(
+                withIDToken: idToken,
+                accessToken: user.accessToken.tokenString
+            )
+            
+            Auth.auth().signIn(with: credential) { authResult, error in
+                if let error = error {
+                    DispatchQueue.main.async {
+                        completion(.failure(error))
+                    }
+                    return
+                }
+                
+                guard let firebaseUser = authResult?.user else {
+                    DispatchQueue.main.async {
+                        completion(.failure(NSError(domain: "AuthManager", code: -1, userInfo: [NSLocalizedDescriptionKey: "Firebase 사용자 정보를 가져오지 못했습니다"])))
+                    }
+                    return
+                }
+                
+                self.saveGoogleUserToFirestore(
+                    firebaseUser: firebaseUser,
+                    googleUser: user,
+                    completion: completion
+                )
+            }
+        }
+    }
+    
+    func loginWithApple(
+        appleIDCredential: ASAuthorizationAppleIDCredential,
+        rawNonce: String,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        guard let appleIDToken = appleIDCredential.identityToken else {
+            DispatchQueue.main.async {
+                completion(.failure(NSError(domain: "AuthManager", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unable to fetch identity token"])))
+            }
+            return
+        }
+        
+        guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+            DispatchQueue.main.async {
+                completion(.failure(NSError(domain: "AuthManager", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unable to serialize token string from data"])))
+            }
+            return
+        }
+        
+        let credential = OAuthProvider.credential(
+            providerID: .apple,
+            idToken: idTokenString,
+            rawNonce: rawNonce
+        )
+        
+        Auth.auth().signIn(with: credential) { [weak self] authResult, error in
+            guard let self else { return }
+            
+            if let error = error {
+                DispatchQueue.main.async {
+                    completion(.failure(error))
+                }
+                return
+            }
+            
+            guard let firebaseUser = authResult?.user else {
+                DispatchQueue.main.async {
+                    completion(.failure(NSError(domain: "AuthManager", code: -1, userInfo: [NSLocalizedDescriptionKey: "Firebase 사용자 정보를 가져오지 못했습니다"])))
+                }
+                return
+            }
+            
+            let fullName = PersonNameComponentsFormatter()
+                .string(from: appleIDCredential.fullName ?? PersonNameComponents())
+            let appleUserInfo = AppleUserInfo(
+                userIdentifier: appleIDCredential.user,
+                fullName: fullName.isEmpty ? nil : fullName,
+                email: appleIDCredential.email
+            )
+            
+            self.saveAppleUserToFirestore(
+                firebaseUser: firebaseUser,
+                appleUserInfo: appleUserInfo,
+                completion: completion
+            )
+        }
+    }
+    
+    // MARK: - Logout
+    
     func logout(completion: @escaping (Bool) -> Void) {
         let provider = AuthSession.currentProvider
         
@@ -64,6 +257,147 @@ final class AuthManager {
         } catch {
             print("Firebase 로그아웃 실패: \(error)")
             return false
+        }
+    }
+    
+    // MARK: - Update or insert userData
+    
+    private func upsertUserDocumentPreservingCreatedAt(
+        firebaseUID: String,
+        userData: [String: Any],
+        completion: @escaping (Error?) -> Void
+    ) {
+        let db = Firestore.firestore()
+        let ref = db.collection("users").document(firebaseUID)
+        
+        db.runTransaction({ txn, errPtr -> Any? in
+            let snap: DocumentSnapshot
+            do {
+                snap = try txn.getDocument(ref)
+            } catch {
+                errPtr?.pointee = error as NSError
+                return nil
+            }
+            
+            var payload = userData
+            payload["lastLoginAt"] = FieldValue.serverTimestamp()
+            
+            if snap.exists {
+                payload.removeValue(forKey: "createdAt")
+                txn.setData(payload, forDocument: ref, merge: true)
+            } else {
+                payload["createdAt"] = FieldValue.serverTimestamp()
+                txn.setData(payload, forDocument: ref, merge: false)
+            }
+            
+            return nil
+        }) { _, error in
+            completion(error)
+        }
+    }
+    
+    private func saveKakaoUserToFirestore(
+        firebaseUser: FirebaseAuth.User,
+        kakaoUserInfo: KakaoUserInfo,
+        appUserId: String,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        let userData: [String: Any] = [
+            "userId": appUserId,
+            "kakaoId": kakaoUserInfo.id,
+            "nickname": kakaoUserInfo.nickname ?? "",
+            "email": kakaoUserInfo.email ?? "",
+            "profileImageUrl": kakaoUserInfo.profileImageUrl ?? "",
+            "provider": "kakao",
+            "createdAt": FieldValue.serverTimestamp()
+        ]
+        
+        upsertUserDocumentPreservingCreatedAt(firebaseUID: firebaseUser.uid, userData: userData) { error in
+            if let error {
+                DispatchQueue.main.async {
+                    completion(.failure(error))
+                }
+                return
+            }
+            
+            AuthSession.setProvider(.kakao)
+            AuthSession.setAppUserId(appUserId)
+            
+            UserDataMigrationManager.shared.migrateAfterKakaoLogin(
+                kakaoId: kakaoUserInfo.id,
+                appUserId: appUserId,
+                currentFirebaseUID: firebaseUser.uid
+            ) { _ in
+                DispatchQueue.main.async {
+                    completion(.success(()))
+                }
+            }
+        }
+    }
+    
+    private func saveGoogleUserToFirestore(
+        firebaseUser: FirebaseAuth.User,
+        googleUser: GIDGoogleUser,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        let appUserId = AppUserID.fromFirebaseUID(firebaseUser.uid)
+        let userData: [String: Any] = [
+            "userId": appUserId,
+            "googleId": googleUser.userID ?? "",
+            "nickname": firebaseUser.displayName ?? "",
+            "email": firebaseUser.email ?? "",
+            "profileImageUrl": firebaseUser.photoURL?.absoluteString ?? "",
+            "provider": "google",
+            "createdAt": FieldValue.serverTimestamp()
+        ]
+        
+        upsertUserDocumentPreservingCreatedAt(firebaseUID: firebaseUser.uid, userData: userData) { error in
+            if let error {
+                DispatchQueue.main.async {
+                    completion(.failure(error))
+                }
+                return
+            }
+            
+            AuthSession.setProvider(.google)
+            AuthSession.setAppUserId(appUserId)
+            
+            DispatchQueue.main.async {
+                completion(.success(()))
+            }
+        }
+    }
+    
+    private func saveAppleUserToFirestore(
+        firebaseUser: FirebaseAuth.User,
+        appleUserInfo: AppleUserInfo,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        let appUserId = AppUserID.fromFirebaseUID(firebaseUser.uid)
+        let userData: [String: Any] = [
+            "userId": appUserId,
+            "appleId": appleUserInfo.userIdentifier,
+            "nickname": appleUserInfo.fullName ?? firebaseUser.displayName ?? "",
+            "email": appleUserInfo.email ?? firebaseUser.email ?? "",
+            "profileImageUrl": "",
+            "provider": "apple",
+            "createdAt": FieldValue.serverTimestamp()
+        ]
+        
+        upsertUserDocumentPreservingCreatedAt(firebaseUID: firebaseUser.uid, userData: userData) { error in
+            if let error {
+                DispatchQueue.main.async {
+                    completion(.failure(error))
+                }
+                return
+            }
+            
+            AuthSession.setProvider(.apple)
+            AuthSession.setAppUserId(appUserId)
+            
+            DispatchQueue.main.async {
+                completion(.success(()))
+            }
         }
     }
 }

--- a/SherlDog/Reusable/Camera/CameraViewModel.swift
+++ b/SherlDog/Reusable/Camera/CameraViewModel.swift
@@ -48,7 +48,9 @@ class CameraViewModel {
     
     private func transform() {
         
-        input.bind { input in
+        input.bind { [weak self] input in
+            guard let self else { return }
+            
             switch input {
             case .sender(let sender):
                 self.output.sender.accept(sender)

--- a/SherlDog/Scene/CommunityTab/View/AddNewContentViewController.swift
+++ b/SherlDog/Scene/CommunityTab/View/AddNewContentViewController.swift
@@ -133,8 +133,12 @@ final class AddNewContentViewController: UIViewController {
         
         viewModel.output.picturesCellDisplay
             .asDriver(onErrorJustReturn: [])
-            .drive(self.picturesCollectionView.rx.items) { collectionView, row, item in
-                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PicturesCollectionViewCell.identifier, for: IndexPath(item: row, section: 0)) as? PicturesCollectionViewCell else { return .init() }
+            .drive(self.picturesCollectionView.rx.items) { [weak self] collectionView, row, item in
+                guard let self,
+                      let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: PicturesCollectionViewCell.identifier,
+                    for: IndexPath(item: row, section: 0)
+                ) as? PicturesCollectionViewCell else { return .init() }
                 
                 cell.setImage(item)
                 

--- a/SherlDog/Scene/CommunityTab/ViewModel/PostDetailViewModel.swift
+++ b/SherlDog/Scene/CommunityTab/ViewModel/PostDetailViewModel.swift
@@ -9,7 +9,6 @@ import RxSwift
 import RxCocoa
 import RxDataSources
 import Differentiator
-import FirebaseAuth
 import FirebaseFirestore
 
 enum CommentEvent {
@@ -121,13 +120,13 @@ final class PostDetailViewModel {
     }
     
     func isWriter(_ writerUserId: String) -> Bool {
-        guard let currentUserId = Auth.auth().currentUser?.uid else { return false }
+        guard let currentUserId = AuthSession.currentAppUserId else { return false }
         
         return writerUserId == currentUserId
     }
     
     func isPosterOrCommenter(commentUserId: String) -> Bool {
-        guard let currentUserId = Auth.auth().currentUser?.uid else { return false }
+        guard let currentUserId = AuthSession.currentAppUserId else { return false }
         
         return self.originalPost.userId == currentUserId || commentUserId == currentUserId
     }
@@ -213,7 +212,7 @@ extension PostDetailViewModel {
         return input
             .flatMap { [weak self] state -> Observable<CommentEvent> in
                 guard let self,
-                      let myUserId = Auth.auth().currentUser?.uid else { return .empty() }
+                      let myUserId = AuthSession.currentAppUserId else { return .empty() }
                 
                 switch state {
                 case .refresh:

--- a/SherlDog/Scene/CommunityTab/ViewModel/ReportViewModel.swift
+++ b/SherlDog/Scene/CommunityTab/ViewModel/ReportViewModel.swift
@@ -8,7 +8,6 @@
 import Foundation
 import RxSwift
 import RxRelay
-import FirebaseAuth
 import FirebaseFirestore
 
 final class ReportViewModel {
@@ -55,7 +54,7 @@ final class ReportViewModel {
                 
                 isLoadingRelay.accept(true)
                 
-                let reporterId = Auth.auth().currentUser?.uid ?? "anonymous"
+                let reporterId = AuthSession.currentAppUserId ?? "anonymous"
                 let now = Date()
                 
                 let targetInfo: (collection: FirestoreCollection,

--- a/SherlDog/Scene/MyPageTab/View/ViewControll/MyPageViewController.swift
+++ b/SherlDog/Scene/MyPageTab/View/ViewControll/MyPageViewController.swift
@@ -315,19 +315,20 @@ class MyPageViewController : UIViewController, UICollectionViewDelegate, UIScrol
             }
             .compactMap { $0 }
             .subscribe(onNext: { [weak self] item in
+                guard let self else { return }
+                
                 switch item {
                 case .profile(let profile):
-                    self?.presentRegistrationViewController(with: profile)
-                        .subscribe(onNext: { _ in
-                        })
-                        .disposed(by: self?.disposeBag ?? DisposeBag())
+                    self.presentRegistrationViewController(with: profile)
+                        .subscribe(onNext: { _ in })
+                        .disposed(by: self.disposeBag)
                 case .addProfile:
-                    self?.presentRegistrationView()
+                    self.presentRegistrationView()
                 }
                 
                 // 선택 해제
-                if let selectedIndexPath = self?.collectionView.indexPathsForSelectedItems?.first {
-                    self?.collectionView.deselectItem(at: selectedIndexPath, animated: true)
+                if let selectedIndexPath = self.collectionView.indexPathsForSelectedItems?.first {
+                    self.collectionView.deselectItem(at: selectedIndexPath, animated: true)
                 }
             })
             .disposed(by: disposeBag)

--- a/SherlDog/Scene/User/HumanProfile/ViewModel/HumanProfileViewModel.swift
+++ b/SherlDog/Scene/User/HumanProfile/ViewModel/HumanProfileViewModel.swift
@@ -127,13 +127,13 @@ final class HumanProfileViewModel {
                 
                 FirestoreManager.shared.createDocument(collection: .humanProfile, data: data, documentId: userId)
                     .subscribe(
-                        onCompleted: {
+                        onCompleted: { [weak self] in
                             DispatchQueue.main.async {
                                 self?.isLoading.accept(false)
                                 self?.saveResult.onNext(.success(()))
                             }
                         },
-                        onError: { error in
+                        onError: { [weak self] error in
                             DispatchQueue.main.async {
                                 self?.isLoading.accept(false)
                                 self?.saveResult.onNext(.failure(error))
@@ -173,13 +173,13 @@ final class HumanProfileViewModel {
                     
                     FirestoreManager.shared.updateDocument(collection: .humanProfile, documentId: userId, data: updatedProfile)
                         .subscribe(
-                            onCompleted: {
+                            onCompleted: { [weak self] in
                                 DispatchQueue.main.async {
                                     self?.isLoading.accept(false)
                                     self?.saveResult.onNext(.success(()))
                                 }
                             },
-                            onError: { error in
+                            onError: { [weak self] error in
                                 DispatchQueue.main.async {
                                     self?.isLoading.accept(false)
                                     self?.saveResult.onNext(.failure(error))

--- a/SherlDog/Scene/User/HumanProfile/ViewModel/SelectAvatarViewModel.swift
+++ b/SherlDog/Scene/User/HumanProfile/ViewModel/SelectAvatarViewModel.swift
@@ -41,7 +41,9 @@ class SelectAvatarViewModel {
     
     private func transform() {
         self.input
-            .bind { input in
+            .bind { [weak self] input in
+                guard let self else { return }
+                
                 switch input {
                 case .avatarSelect(let index):
                     self.output.selectedAvatar.accept(self.data[index])

--- a/SherlDog/Scene/User/LogIn/ViewModel/LoginViewModel.swift
+++ b/SherlDog/Scene/User/LogIn/ViewModel/LoginViewModel.swift
@@ -9,11 +9,6 @@ import Foundation
 import UIKit
 import RxSwift
 import RxCocoa
-import FirebaseAuth
-import FirebaseFirestore
-import GoogleSignIn
-import KakaoSDKUser
-import KakaoSDKAuth
 import AuthenticationServices
 import CryptoKit
 
@@ -130,160 +125,25 @@ extension LoginViewModel {
         })
         .disposed(by: disposeBag)
     }
-    
-    private func upsertUserDocumentPreservingCreatedAt(
-        firebaseUID: String,
-        userData: [String: Any],
-        completion: @escaping (Error?) -> Void
-    ) {
-        let db = Firestore.firestore()
-        let ref = db.collection("users").document(firebaseUID)
-        
-        db.runTransaction({ txn, errPtr -> Any? in
-            let snap: DocumentSnapshot
-            do {
-                snap = try txn.getDocument(ref)
-            } catch {
-                errPtr?.pointee = error as NSError
-                return nil
-            }
-            
-            var payload = userData
-            payload["lastLoginAt"] = FieldValue.serverTimestamp()
-            
-            if snap.exists {
-                //기존 문서면 createdAt은 절대 건드리지 않기
-                payload.removeValue(forKey: "createdAt")
-                txn.setData(payload, forDocument: ref, merge: true)
-            } else {
-                //최초 생성일만 기록
-                payload["createdAt"] = FieldValue.serverTimestamp()
-                txn.setData(payload, forDocument: ref, merge: false)
-            }
-            
-            return nil
-        }) { _, error in
-            completion(error)
-        }
-    }
 }
 
 // MARK: - Kakao Login
 extension LoginViewModel {
     
-    /// 카카오 버튼 탭 처리
     private func loginWithKakao() {
         guard beginLoadingIfPossible() else { return }
         
-        // Kakao SDK 로그인 completion
-        let completion: (OAuthToken?, Error?) -> Void = { [weak self] token, error in
+        AuthManager.shared.loginWithKakao { [weak self] result in
             guard let self else { return }
+            self.endLoading()
             
-            if let error = error {
-                self.endLoading()
-                let msg = error.localizedDescription.lowercased()
-                if msg.contains("cancel") || msg.contains("취소") { return }
-                self.showErrorSubject.onNext(error.localizedDescription)
-                return
-            }
-            
-            UserApi.shared.me { user, error in
-                if let error = error {
-                    self.endLoading()
-                    self.showErrorSubject.onNext(error.localizedDescription)
-                    return
-                }
-                
-                guard let user = user else {
-                    self.endLoading()
-                    self.showErrorSubject.onNext("사용자 정보를 가져올 수 없습니다.")
-                    return
-                }
-                
-                let userInfo = KakaoUserInfo(from: user)
-                let appUserId = AppUserID.fromKakaoID(userInfo.id)   // "kakao:\(id)" 형태
-                
-                self.linkKakaoToFirebase(
-                    userInfo: userInfo,
-                    appUserId: appUserId
-                )
-            }
-        }
-        
-        // 카카오톡 앱 가능하면 톡으로, 아니면 계정 로그인
-        if UserApi.isKakaoTalkLoginAvailable() {
-            UserApi.shared.loginWithKakaoTalk(completion: completion)
-        } else {
-            UserApi.shared.loginWithKakaoAccount(completion: completion)
-        }
-    }
-    
-    /// Kakao SDK 로그인 성공 후, Firebase 익명 로그인 (Firestore 접근용)
-    private func linkKakaoToFirebase(
-        userInfo: KakaoUserInfo,
-        appUserId: String
-    ) {
-        Auth.auth().signInAnonymously { [weak self] authResult, error in
-            guard let self else { return }
-            
-            if let error = error {
-                self.endLoading()
-                self.showErrorSubject.onNext(error.localizedDescription)
-                return
-            }
-            
-            guard let firebaseUser = authResult?.user else {
-                self.endLoading()
-                self.showErrorSubject.onNext("Firebase 인증 실패")
-                return
-            }
-            
-            self.saveKakaoUserToFirestore(
-                firebaseUser: firebaseUser,
-                kakaoUserInfo: userInfo,
-                appUserId: appUserId
-            )
-        }
-    }
-    
-    /// Firestore users 컬렉션에 Kakao 유저 정보 저장 + 로그인 후 마이그레이션
-    private func saveKakaoUserToFirestore(
-        firebaseUser: FirebaseAuth.User,
-        kakaoUserInfo: KakaoUserInfo,
-        appUserId: String
-    ) {
-        let db = Firestore.firestore()
-        
-        let userData: [String: Any] = [
-            "userId": appUserId,
-            "kakaoId": kakaoUserInfo.id,
-            "nickname": kakaoUserInfo.nickname ?? "",
-            "email": kakaoUserInfo.email ?? "",
-            "profileImageUrl": kakaoUserInfo.profileImageUrl ?? "",
-            "provider": "kakao",
-            "createdAt": FieldValue.serverTimestamp()
-        ]
-        
-        upsertUserDocumentPreservingCreatedAt(firebaseUID: firebaseUser.uid, userData: userData) { [weak self] error in
-            guard let self else { return }
-            
-            if let error = error {
-                self.endLoading()
-                self.showErrorSubject.onNext(error.localizedDescription)
-                return
-            }
-            
-            AuthSession.setProvider(.kakao)
-            AuthSession.setAppUserId(appUserId)
-            
-            UserDataMigrationManager.shared.migrateAfterKakaoLogin(
-                kakaoId: kakaoUserInfo.id,
-                appUserId: appUserId,
-                currentFirebaseUID: firebaseUser.uid
-            ) { [weak self] _ in
-                guard let self else { return }
-                self.endLoading()
+            switch result {
+            case .success:
                 self.checkPetProfiles()
+            case .failure(let error):
+                let message = error.localizedDescription.lowercased()
+                if message.contains("cancel") || message.contains("취소") { return }
+                self.showErrorSubject.onNext(error.localizedDescription)
             }
         }
     }
@@ -303,78 +163,16 @@ extension LoginViewModel {
             return
         }
         
-        GIDSignIn.sharedInstance.signIn(withPresenting: rootVC) { [weak self] result, error in
+        AuthManager.shared.loginWithGoogle(presentingViewController: rootVC) { [weak self] result in
             guard let self else { return }
-            
-            if let error = error {
-                self.endLoading()
-                self.showErrorSubject.onNext(error.localizedDescription)
-                return
-            }
-            
-            guard
-                let user = result?.user,
-                let idToken = user.idToken?.tokenString
-            else {
-                self.endLoading()
-                self.showErrorSubject.onNext("인증 토큰을 가져오지 못했습니다")
-                return
-            }
-            
-            let credential = GoogleAuthProvider.credential(
-                withIDToken: idToken,
-                accessToken: user.accessToken.tokenString
-            )
-            
-            Auth.auth().signIn(with: credential) { authResult, error in
-                if let error = error {
-                    self.endLoading()
-                    self.showErrorSubject.onNext(error.localizedDescription)
-                    return
-                }
-                
-                guard let firebaseUser = authResult?.user else {
-                    self.endLoading()
-                    self.showErrorSubject.onNext("Firebase 사용자 정보를 가져오지 못했습니다")
-                    return
-                }
-                
-                self.saveGoogleUserToFirestore(firebaseUser: firebaseUser, googleUser: user)
-            }
-        }
-    }
-    
-    private func saveGoogleUserToFirestore(
-        firebaseUser: FirebaseAuth.User,
-        googleUser: GIDGoogleUser
-    ) {
-        let db = Firestore.firestore()
-        let appUserId = AppUserID.fromFirebaseUID(firebaseUser.uid)
-        
-        let userData: [String: Any] = [
-            "userId": appUserId,
-            "googleId": googleUser.userID ?? "",
-            "nickname": firebaseUser.displayName ?? "",
-            "email": firebaseUser.email ?? "",
-            "profileImageUrl": firebaseUser.photoURL?.absoluteString ?? "",
-            "provider": "google",
-            "createdAt": FieldValue.serverTimestamp()
-        ]
-        
-        upsertUserDocumentPreservingCreatedAt(firebaseUID: firebaseUser.uid, userData: userData) { [weak self] error in
-            guard let self else { return }
-
-            if let error = error {
-                self.endLoading()
-                self.showErrorSubject.onNext(error.localizedDescription)
-                return
-            }
-
-            AuthSession.setProvider(.google)
-            AuthSession.setAppUserId(appUserId)
-
             self.endLoading()
-            self.checkPetProfiles()
+            
+            switch result {
+            case .success:
+                self.checkPetProfiles()
+            case .failure(let error):
+                self.showErrorSubject.onNext(error.localizedDescription)
+            }
         }
     }
 }
@@ -397,40 +195,6 @@ extension LoginViewModel {
         authorizationController.presentationContextProvider = self
         authorizationController.performRequests()
     }
-    
-    private func saveAppleUserToFirestore(
-        firebaseUser: FirebaseAuth.User,
-        appleUserInfo: AppleUserInfo
-    ) {
-        let db = Firestore.firestore()
-        let appUserId = AppUserID.fromFirebaseUID(firebaseUser.uid)
-        
-        let userData: [String: Any] = [
-            "userId": appUserId,
-            "appleId": appleUserInfo.userIdentifier,
-            "nickname": appleUserInfo.fullName ?? firebaseUser.displayName ?? "",
-            "email": appleUserInfo.email ?? firebaseUser.email ?? "",
-            "profileImageUrl": "",
-            "provider": "apple",
-            "createdAt": FieldValue.serverTimestamp()
-        ]
-        
-        upsertUserDocumentPreservingCreatedAt(firebaseUID: firebaseUser.uid, userData: userData) { [weak self] error in
-            guard let self else { return }
-
-            if let error = error {
-                self.endLoading()
-                self.showErrorSubject.onNext(error.localizedDescription)
-                return
-            }
-
-            AuthSession.setProvider(.apple)
-            AuthSession.setAppUserId(appUserId)
-
-            self.endLoading()
-            self.checkPetProfiles()
-        }
-    }
 }
 
 // MARK: - Apple SignIn Delegate
@@ -452,52 +216,16 @@ extension LoginViewModel: ASAuthorizationControllerDelegate {
             return
         }
         
-        guard let appleIDToken = appleIDCredential.identityToken else {
-            endLoading()
-            showErrorSubject.onNext("Unable to fetch identity token")
-            return
-        }
-        
-        guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
-            endLoading()
-            showErrorSubject.onNext("Unable to serialize token string from data")
-            return
-        }
-        
-        let credential = OAuthProvider.credential(
-            providerID: .apple,
-            idToken: idTokenString,
-            rawNonce: nonce
-        )
-        
-        Auth.auth().signIn(with: credential) { [weak self] authResult, error in
+        AuthManager.shared.loginWithApple(appleIDCredential: appleIDCredential, rawNonce: nonce) { [weak self] result in
             guard let self else { return }
+            self.endLoading()
             
-            if let error = error {
-                self.endLoading()
+            switch result {
+            case .success:
+                self.checkPetProfiles()
+            case .failure(let error):
                 self.showErrorSubject.onNext(error.localizedDescription)
-                return
             }
-            
-            guard let firebaseUser = authResult?.user else {
-                self.endLoading()
-                self.showErrorSubject.onNext("Firebase 사용자 정보를 가져오지 못했습니다")
-                return
-            }
-            
-            let fullName = PersonNameComponentsFormatter()
-                .string(from: appleIDCredential.fullName ?? PersonNameComponents())
-            
-            let appleUserInfo = AppleUserInfo(
-                userIdentifier: appleIDCredential.user,
-                fullName: fullName.isEmpty ? nil : fullName,
-                email: appleIDCredential.email
-            )
-            
-            self.saveAppleUserToFirestore(
-                firebaseUser: firebaseUser,
-                appleUserInfo: appleUserInfo
-            )
         }
     }
     
@@ -516,7 +244,7 @@ extension LoginViewModel: ASAuthorizationControllerDelegate {
                 showErrorSubject.onNext("요청을 처리할 수 없습니다")
             case .unknown:
                 showErrorSubject.onNext("알 수 없는 오류가 발생했습니다")
-            @unknown default:
+            default:
                 showErrorSubject.onNext("애플 로그인 오류: \(error.localizedDescription)")
             }
         } else {
@@ -535,13 +263,6 @@ extension LoginViewModel: ASAuthorizationControllerPresentationContextProviding 
         }
         return window
     }
-}
-
-// MARK: - Apple User Info
-struct AppleUserInfo {
-    let userIdentifier: String
-    let fullName: String?
-    let email: String?
 }
 
 // MARK: - Nonce Helpers
@@ -579,8 +300,4 @@ extension LoginViewModel {
         let hashedData = SHA256.hash(data: inputData)
         return hashedData.map { String(format: "%02x", $0) }.joined()
     }
-}
-
-private func currentAppUserId() -> String? {
-    return AuthSession.currentAppUserId
 }


### PR DESCRIPTION
close #433 

## *⛳️ Work Description*

- [weak self]가 적용되어 있지 않은 클로저에 [weak self]를 추가해 Retain cycle 방지
- LoginViewModel에 Firebase에 직접 접근하는 코드 다수 발견하여 AuthManager로 분리 및 적용
- 외부에서 직접 Auth.auth().currentUser?.uid로 접근하는 코드 수정

## *📸 Screenshot*

| before | After | 
| -- | -- |
|  |  |
리팩토링이므로 스크린 샷은 없습니다

## *📢 To Reviewers*

- 

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
