### PR TITLE
[Fix] 온보딩 문구 수정

### DIFF
--- a/SherlDog/Scene/Onboarding/OnboardingModel.swift
+++ b/SherlDog/Scene/Onboarding/OnboardingModel.swift
@@ -16,7 +16,7 @@ struct OnboardingModel {
             text: "반려견은 멍탐정,\n당신은 멍탐정의 조수!\n매일의 산책,\n오늘은 수사로 떠나봐요.",
             lottieName: "Onboarding1"),
         OnboardingStep(
-            text: "수사 중 만난 풍경이나 순간을\n단서로 남기고, 다른 멍탐정들이\n남긴 단서도 함께 살펴보세요.",
+            text: "멍탐정의 산책길!\n수사 중 발견한 특별한 순간을\n단서로 저장해 보세요.",
             lottieName: "Onboarding2"),
         OnboardingStep(
             text: "수사가 끝나면 경로와 운동데이터,\n시간이 오늘의 수사일지에\n자동으로 기록돼요!",


### PR DESCRIPTION
close #No

## *⛳️ Work Description*

- 커뮤티니 기능 업뎃 전까지 보여줄 온보딩 문구 수정입니다!
혜진님의 요청대로 문구 수정했습니다.

## *📸 Screenshot*

| before | After |
| -- | -- |
| <img width="420" height="733" alt="KakaoTalk_Photo_2026-03-10-21-05-03" src="https://github.com/user-attachments/assets/c896daea-be53-495d-9fff-977867dc2dbc" /> | <img width="1080" height="2340" alt="Simulator Screenshot - iPhone 12 mini - 2026-03-10 at 20 59 10" src="https://github.com/user-attachments/assets/a99e2d85-0129-450d-89c0-186e6703191a" /> |


## *📢 To Reviewers*

- 아이폰 12미니에서도 깨지지 않고 잘 보입니다! 

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
