### PR TITLE
[Fix] 아이패드에서 잘리는 부분 수정

### DIFF
--- a/SherlDog/Scene/User/LogIn/View/LoginViewController.swift
+++ b/SherlDog/Scene/User/LogIn/View/LoginViewController.swift
@@ -77,7 +77,7 @@ class LoginViewController: UIViewController {
     
     private func setupConstraints() {
         headerLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(16)
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
             $0.centerX.equalToSuperview()
         }
         
@@ -105,7 +105,7 @@ class LoginViewController: UIViewController {
             $0.centerX.equalToSuperview()
             $0.height.equalTo(54)
             $0.width.equalToSuperview().multipliedBy(0.75)
-            $0.top.greaterThanOrEqualTo(helloLabel2.snp.bottom).offset(24)
+            $0.top.greaterThanOrEqualTo(helloLabel2.snp.bottom)
         }
         
         appleButton.snp.makeConstraints {

--- a/SherlDog/Scene/User/LogIn/View/LoginViewController.swift
+++ b/SherlDog/Scene/User/LogIn/View/LoginViewController.swift
@@ -77,7 +77,7 @@ class LoginViewController: UIViewController {
     
     private func setupConstraints() {
         headerLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(78)
+            $0.top.equalToSuperview().inset(16)
             $0.centerX.equalToSuperview()
         }
         
@@ -90,41 +90,43 @@ class LoginViewController: UIViewController {
 
         helloLabel.snp.makeConstraints {
             $0.top.equalTo(logo.snp.bottom).offset(28)
+            $0.horizontalEdges.equalToSuperview().inset(12)
             $0.centerX.equalToSuperview()
         }
 
         helloLabel2.snp.makeConstraints {
-            $0.top.equalTo(helloLabel.snp.bottom).offset(10)
+            $0.top.equalTo(helloLabel.snp.bottom).offset(4)
+            $0.horizontalEdges.equalToSuperview().inset(12)
             $0.centerX.equalToSuperview()
         }
         
         joinImage.snp.makeConstraints {
-            $0.bottom.equalTo(appleButton.snp.top).offset(-16)
+            $0.bottom.equalTo(appleButton.snp.top).offset(-12)
             $0.centerX.equalToSuperview()
-            $0.height.equalTo(80)
+            $0.height.equalTo(54)
             $0.width.equalToSuperview().multipliedBy(0.75)
             $0.top.greaterThanOrEqualTo(helloLabel2.snp.bottom).offset(24)
         }
         
         appleButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.height.equalTo(54)
+            $0.height.equalTo(52)
             $0.width.equalToSuperview().multipliedBy(0.85)
-            $0.bottom.equalTo(kakaoButton.snp.top).offset(-12)
+            $0.bottom.equalTo(kakaoButton.snp.top).offset(-8)
             $0.width.lessThanOrEqualTo(360)
         }
         
         kakaoButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.height.equalTo(54)
+            $0.height.equalTo(52)
             $0.width.equalToSuperview().multipliedBy(0.85)
-            $0.bottom.equalTo(googleButton.snp.top).offset(-12)
+            $0.bottom.equalTo(googleButton.snp.top).offset(-8)
             $0.width.lessThanOrEqualTo(360)
         }
 
         googleButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.height.equalTo(54)
+            $0.height.equalTo(52)
             $0.width.equalToSuperview().multipliedBy(0.85)
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(32)
             $0.width.lessThanOrEqualTo(360)


### PR DESCRIPTION
close #440 

## *⛳️ Work Description*

- 로그인 뷰의 UI가 아이패드에서 정상적으로 표시되지 않던 문제 수정

## *📸 Screenshot*

| before | After | 
| -- | -- |
| <img src="https://github.com/user-attachments/assets/e66556e7-1029-489a-843f-4cc6353df8f7"  width="300"/> | <img src="https://github.com/user-attachments/assets/545c4994-22fc-4e89-b74d-7002dd0a084d"  width="300"/> |

## *📢 To Reviewers*

- 

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거하기.
- [ ]  컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
